### PR TITLE
Issue #3: User Message Rendering

### DIFF
--- a/claude_session_player/formatter.py
+++ b/claude_session_player/formatter.py
@@ -1,15 +1,38 @@
 """Formatting helpers: convert screen state to markdown."""
 
-from .models import ScreenState
+from __future__ import annotations
+
+from .models import ScreenState, SystemOutput, UserMessage
+
+
+def format_user_text(text: str) -> str:
+    """Format user input text with ❯ prompt prefix.
+
+    First line gets ``❯ `` prefix, subsequent lines are indented 2 spaces.
+    """
+    lines = text.split("\n")
+    if not lines or (len(lines) == 1 and lines[0] == ""):
+        return "❯"
+    result = [f"❯ {lines[0]}"]
+    for line in lines[1:]:
+        result.append(f"  {line}")
+    return "\n".join(result)
+
+
+def format_element(element: object) -> str:
+    """Format a single screen element to its markdown representation."""
+    if isinstance(element, UserMessage):
+        return element.text
+    if isinstance(element, SystemOutput):
+        return element.text
+    return ""
 
 
 def to_markdown(state: ScreenState) -> str:
-    """Render the current screen state as markdown text.
-
-    Args:
-        state: The screen state to format.
-
-    Returns:
-        Markdown string representation of the screen.
-    """
-    raise NotImplementedError("Implemented in issue 03-04")
+    """Render the current screen state as markdown text."""
+    parts = []
+    for element in state.elements:
+        formatted = format_element(element)
+        if formatted:
+            parts.append(formatted)
+    return "\n\n".join(parts)

--- a/claude_session_player/models.py
+++ b/claude_session_player/models.py
@@ -69,7 +69,9 @@ class ScreenState:
 
     def to_markdown(self) -> str:
         """Render current state as markdown text."""
-        raise NotImplementedError("Implemented in issue 03-04")
+        from .formatter import to_markdown
+
+        return to_markdown(self)
 
     def clear(self) -> None:
         """Clear all state (used on compaction)."""

--- a/claude_session_player/renderer.py
+++ b/claude_session_player/renderer.py
@@ -1,6 +1,10 @@
 """Render function: processes JSONL lines into screen state."""
 
-from .models import ScreenState
+from __future__ import annotations
+
+from .formatter import format_user_text
+from .models import ScreenState, SystemOutput, UserMessage
+from .parser import LineType, classify_line, get_local_command_text, get_user_text
 
 
 def render(state: ScreenState, line: dict) -> ScreenState:
@@ -13,4 +17,26 @@ def render(state: ScreenState, line: dict) -> ScreenState:
     Returns:
         The same state object, updated.
     """
-    raise NotImplementedError("Implemented in issue 02")
+    line_type = classify_line(line)
+
+    if line_type is LineType.USER_INPUT:
+        _render_user_input(state, line)
+    elif line_type is LineType.LOCAL_COMMAND_OUTPUT:
+        _render_local_command(state, line)
+    # INVISIBLE and unhandled types: do nothing (future issues add more cases)
+
+    return state
+
+
+def _render_user_input(state: ScreenState, line: dict) -> None:
+    """Render a user input message."""
+    text = get_user_text(line)
+    formatted = format_user_text(text)
+    state.elements.append(UserMessage(text=formatted))
+    state.current_request_id = None
+
+
+def _render_local_command(state: ScreenState, line: dict) -> None:
+    """Render local command output."""
+    text = get_local_command_text(line)
+    state.elements.append(SystemOutput(text=text))

--- a/issues/worklogs/03-worklog.md
+++ b/issues/worklogs/03-worklog.md
@@ -1,0 +1,44 @@
+# Issue 03 Worklog: User Message Rendering
+
+## Files Created/Modified
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/renderer.py` | Full implementation: `render()` dispatch, `_render_user_input`, `_render_local_command` |
+| `claude_session_player/formatter.py` | Full implementation: `format_user_text`, `format_element`, `to_markdown` |
+| `claude_session_player/models.py` | Updated `ScreenState.to_markdown()` to delegate to `formatter.to_markdown()` |
+| `tests/test_renderer.py` | 14 tests: render dispatch, state mutation, integration |
+| `tests/test_formatter.py` | 16 tests: format_user_text, format_element, to_markdown |
+| `tests/test_models.py` | Updated `TestToMarkdownNotImplemented` → `TestToMarkdownImplemented` (to_markdown now works) |
+
+## Decisions Made
+
+- **No `match` statements**: The issue spec shows `match/case` syntax but the system Python is 3.9 which doesn't support structural pattern matching (3.10+). Used `if/isinstance` chains and `is` comparisons for enum dispatch instead. This aligns with Issue 01's approach of using `from __future__ import annotations` for type hints while keeping runtime syntax 3.9-compatible.
+- **Lazy import in `to_markdown`**: `ScreenState.to_markdown()` uses a local import of `formatter.to_markdown` to avoid a circular import between `models.py` and `formatter.py`.
+- **`format_user_text` handles empty string**: An empty string input produces just `❯` (no trailing space), consistent with the spec's "Empty user message → `❯`" requirement.
+
+## Formatting Edge Cases
+
+- Empty user text → `❯` (no space after prompt)
+- Single line → `❯ text`
+- Multi-line → first line `❯ text`, continuation lines indented with 2 spaces
+- Special characters (markdown syntax, unicode) pass through unchanged
+
+## Test Results
+
+```
+106 passed in 0.51s
+```
+
+### Test Breakdown (30 new tests)
+- **test_formatter.py** (16): 6 format_user_text, 4 format_element, 6 to_markdown
+- **test_renderer.py** (14): 4 render user input, 1 render local command, 3 render invisible, 3 state mutation, 3 integration
+
+### Prior tests
+- 20 tests from Issue 01 (`test_models.py`) — 1 updated (NotImplementedError → empty string check)
+- 56 tests from Issue 02 (`test_parser.py`) — all pass unchanged
+
+## Changes to Models from Issue 01
+
+- `ScreenState.to_markdown()` no longer raises `NotImplementedError` — it now delegates to `formatter.to_markdown(self)`
+- The corresponding test was updated from asserting `NotImplementedError` to asserting empty string for empty state

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,104 @@
+"""Tests for formatting helpers and to_markdown output."""
+
+from __future__ import annotations
+
+from claude_session_player.formatter import format_element, format_user_text, to_markdown
+from claude_session_player.models import (
+    AssistantText,
+    ScreenState,
+    SystemOutput,
+    ThinkingIndicator,
+    UserMessage,
+)
+
+
+class TestFormatUserText:
+    """Tests for format_user_text."""
+
+    def test_single_line(self) -> None:
+        assert format_user_text("hello") == "❯ hello"
+
+    def test_multiline(self) -> None:
+        result = format_user_text("line one\nline two\nline three")
+        assert result == "❯ line one\n  line two\n  line three"
+
+    def test_empty_string(self) -> None:
+        assert format_user_text("") == "❯"
+
+    def test_single_newline(self) -> None:
+        result = format_user_text("first\nsecond")
+        assert result == "❯ first\n  second"
+
+    def test_unicode(self) -> None:
+        assert format_user_text("日本語テスト") == "❯ 日本語テスト"
+
+    def test_markdown_chars(self) -> None:
+        result = format_user_text("**bold** and `code`")
+        assert result == "❯ **bold** and `code`"
+
+
+class TestFormatElement:
+    """Tests for format_element."""
+
+    def test_user_message(self) -> None:
+        elem = UserMessage(text="❯ hello")
+        assert format_element(elem) == "❯ hello"
+
+    def test_system_output(self) -> None:
+        elem = SystemOutput(text="some output")
+        assert format_element(elem) == "some output"
+
+    def test_unknown_element(self) -> None:
+        elem = ThinkingIndicator()
+        assert format_element(elem) == ""
+
+    def test_assistant_text_empty_for_now(self) -> None:
+        elem = AssistantText(text="response")
+        assert format_element(elem) == ""
+
+
+class TestToMarkdown:
+    """Tests for to_markdown output."""
+
+    def test_empty_state(self) -> None:
+        state = ScreenState()
+        assert to_markdown(state) == ""
+
+    def test_single_user_message(self) -> None:
+        state = ScreenState(elements=[UserMessage(text="❯ hello")])
+        assert to_markdown(state) == "❯ hello"
+
+    def test_two_user_messages(self) -> None:
+        state = ScreenState(
+            elements=[
+                UserMessage(text="❯ first"),
+                UserMessage(text="❯ second"),
+            ]
+        )
+        assert to_markdown(state) == "❯ first\n\n❯ second"
+
+    def test_user_plus_system_output(self) -> None:
+        state = ScreenState(
+            elements=[
+                UserMessage(text="❯ hello"),
+                SystemOutput(text="output here"),
+            ]
+        )
+        result = to_markdown(state)
+        assert result == "❯ hello\n\noutput here"
+
+    def test_mixed_elements_in_order(self) -> None:
+        state = ScreenState(
+            elements=[
+                UserMessage(text="❯ first"),
+                SystemOutput(text="middle"),
+                UserMessage(text="❯ last"),
+            ]
+        )
+        result = to_markdown(state)
+        assert result == "❯ first\n\nmiddle\n\n❯ last"
+
+    def test_state_to_markdown_delegates(self) -> None:
+        """Verify ScreenState.to_markdown() uses formatter."""
+        state = ScreenState(elements=[UserMessage(text="❯ via method")])
+        assert state.to_markdown() == "❯ via method"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,9 +151,8 @@ class TestTypeNarrowing:
         assert not isinstance(msg, ToolCall)
 
 
-class TestToMarkdownNotImplemented:
-    """Test that to_markdown raises NotImplementedError."""
+class TestToMarkdownImplemented:
+    """Test that to_markdown works on empty state."""
 
-    def test_to_markdown_raises(self, empty_state: ScreenState) -> None:
-        with pytest.raises(NotImplementedError):
-            empty_state.to_markdown()
+    def test_to_markdown_empty(self, empty_state: ScreenState) -> None:
+        assert empty_state.to_markdown() == ""

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,132 @@
+"""Tests for render function dispatch and state mutation."""
+
+from __future__ import annotations
+
+from claude_session_player.models import ScreenState, SystemOutput, UserMessage
+from claude_session_player.renderer import render
+
+
+class TestRenderUserInput:
+    """Tests for rendering user input messages."""
+
+    def test_single_line(self, empty_state: ScreenState, user_input_line: dict) -> None:
+        result = render(empty_state, user_input_line)
+        assert len(result.elements) == 1
+        assert isinstance(result.elements[0], UserMessage)
+        assert result.elements[0].text == "❯ hello world"
+
+    def test_multiline(self, empty_state: ScreenState, user_input_multiline_line: dict) -> None:
+        result = render(empty_state, user_input_multiline_line)
+        assert isinstance(result.elements[0], UserMessage)
+        assert result.elements[0].text == "❯ line one\n  line two\n  line three"
+
+    def test_empty_content(self, empty_state: ScreenState) -> None:
+        line = {
+            "type": "user",
+            "isMeta": False,
+            "message": {"role": "user", "content": ""},
+        }
+        result = render(empty_state, line)
+        assert len(result.elements) == 1
+        assert result.elements[0].text == "❯"
+
+    def test_special_chars(self, empty_state: ScreenState) -> None:
+        line = {
+            "type": "user",
+            "isMeta": False,
+            "message": {"role": "user", "content": "**bold** `code` <tag> ñ 日本語"},
+        }
+        result = render(empty_state, line)
+        assert result.elements[0].text == "❯ **bold** `code` <tag> ñ 日本語"
+
+
+class TestRenderLocalCommand:
+    """Tests for rendering local command output."""
+
+    def test_local_command_output(
+        self, empty_state: ScreenState, local_command_output_line: dict
+    ) -> None:
+        result = render(empty_state, local_command_output_line)
+        assert len(result.elements) == 1
+        assert isinstance(result.elements[0], SystemOutput)
+        assert result.elements[0].text == "git status output here"
+
+
+class TestRenderInvisible:
+    """Tests for invisible message handling."""
+
+    def test_invisible_no_change(self, empty_state: ScreenState, user_meta_line: dict) -> None:
+        result = render(empty_state, user_meta_line)
+        assert len(result.elements) == 0
+
+    def test_meta_user_invisible(self, empty_state: ScreenState) -> None:
+        line = {
+            "type": "user",
+            "isMeta": True,
+            "message": {"role": "user", "content": "skill expansion"},
+        }
+        result = render(empty_state, line)
+        assert len(result.elements) == 0
+
+    def test_file_history_invisible(
+        self, empty_state: ScreenState, file_history_snapshot_line: dict
+    ) -> None:
+        result = render(empty_state, file_history_snapshot_line)
+        assert len(result.elements) == 0
+
+
+class TestStateMutation:
+    """Tests for state mutation behavior."""
+
+    def test_returns_same_object(self, empty_state: ScreenState, user_input_line: dict) -> None:
+        result = render(empty_state, user_input_line)
+        assert result is empty_state
+
+    def test_elements_grow_by_one(
+        self, empty_state: ScreenState, user_input_line: dict
+    ) -> None:
+        assert len(empty_state.elements) == 0
+        render(empty_state, user_input_line)
+        assert len(empty_state.elements) == 1
+
+    def test_request_id_reset(self, user_input_line: dict) -> None:
+        state = ScreenState(current_request_id="req_old")
+        render(state, user_input_line)
+        assert state.current_request_id is None
+
+
+class TestRenderIntegration:
+    """Mini integration tests for render dispatch."""
+
+    def test_invisible_user_invisible(
+        self,
+        empty_state: ScreenState,
+        file_history_snapshot_line: dict,
+        user_input_line: dict,
+        summary_line: dict,
+    ) -> None:
+        """Feed invisible, user input, invisible → 1 element."""
+        render(empty_state, file_history_snapshot_line)
+        render(empty_state, user_input_line)
+        render(empty_state, summary_line)
+        assert len(empty_state.elements) == 1
+
+    def test_user_plus_local_command(
+        self,
+        empty_state: ScreenState,
+        user_input_line: dict,
+        local_command_output_line: dict,
+    ) -> None:
+        """User input + local command → 2 elements, correct markdown."""
+        render(empty_state, user_input_line)
+        render(empty_state, local_command_output_line)
+        assert len(empty_state.elements) == 2
+        md = empty_state.to_markdown()
+        assert "❯ hello world" in md
+        assert "git status output here" in md
+
+    def test_unhandled_types_pass(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        """Unhandled types (e.g., TOOL_USE) don't crash and don't add elements."""
+        result = render(empty_state, tool_use_line)
+        assert result is empty_state
+        assert len(result.elements) == 0


### PR DESCRIPTION
## Summary

- Implement `render()` dispatch for `USER_INPUT`, `LOCAL_COMMAND_OUTPUT`, and `INVISIBLE` line types
- Add `format_user_text()` with `❯` prompt prefix and 2-space continuation indent
- Implement `format_element()` and `to_markdown()` for `UserMessage` and `SystemOutput` elements
- Wire `ScreenState.to_markdown()` to delegate to `formatter.to_markdown()`

## Test plan

- [x] 14 renderer tests: user input (single/multi/empty/special chars), local command, invisible, state mutation, integration
- [x] 16 formatter tests: format_user_text, format_element, to_markdown with various element combinations
- [x] Updated 1 prior test (NotImplementedError → empty string)
- [x] All 106 tests passing (20 models + 56 parser + 16 formatter + 14 renderer)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)