### PR TITLE
Issue #4: Assistant Text Block Rendering

### DIFF
--- a/claude_session_player/formatter.py
+++ b/claude_session_player/formatter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .models import ScreenState, SystemOutput, UserMessage
+from .models import AssistantText, ScreenState, SystemOutput, UserMessage
 
 
 def format_user_text(text: str) -> str:
@@ -19,20 +19,55 @@ def format_user_text(text: str) -> str:
     return "\n".join(result)
 
 
+def format_assistant_text(text: str) -> str:
+    """Format assistant text with ● prefix.
+
+    First line gets ``● `` prefix, continuation lines are indented 2 spaces.
+    Markdown in text is passed through verbatim.
+    """
+    lines = text.split("\n")
+    if not lines or (len(lines) == 1 and lines[0] == ""):
+        return "●"
+    result = [f"● {lines[0]}"]
+    for line in lines[1:]:
+        result.append(f"  {line}")
+    return "\n".join(result)
+
+
 def format_element(element: object) -> str:
     """Format a single screen element to its markdown representation."""
     if isinstance(element, UserMessage):
         return element.text
     if isinstance(element, SystemOutput):
         return element.text
+    if isinstance(element, AssistantText):
+        return element.text
     return ""
 
 
 def to_markdown(state: ScreenState) -> str:
-    """Render the current screen state as markdown text."""
-    parts = []
+    """Render the current screen state as markdown text.
+
+    Elements sharing the same non-None request_id are grouped together
+    with no blank line between them. Different groups are separated by
+    a blank line.
+    """
+    parts: list[str] = []
+    prev_request_id: str | None = None
+
     for element in state.elements:
         formatted = format_element(element)
-        if formatted:
-            parts.append(formatted)
-    return "\n\n".join(parts)
+        if not formatted:
+            continue
+
+        current_rid = getattr(element, "request_id", None)
+
+        # Insert blank line separator unless both previous and current
+        # share the same non-None request_id
+        if parts and not (prev_request_id and current_rid and prev_request_id == current_rid):
+            parts.append("")  # blank line
+
+        parts.append(formatted)
+        prev_request_id = current_rid
+
+    return "\n".join(parts)

--- a/claude_session_player/models.py
+++ b/claude_session_player/models.py
@@ -18,6 +18,7 @@ class AssistantText:
     """Assistant's text response. Rendered as ● text with markdown passthrough."""
 
     text: str
+    request_id: str | None = None
 
 
 @dataclass

--- a/issues/worklogs/04-worklog.md
+++ b/issues/worklogs/04-worklog.md
@@ -1,0 +1,49 @@
+# Issue 04 Worklog: Assistant Text Block Rendering
+
+## Files Modified
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/models.py` | Added `request_id: str \| None = None` field to `AssistantText` dataclass |
+| `claude_session_player/formatter.py` | Added `format_assistant_text()`, updated `format_element()` for `AssistantText`, rewrote `to_markdown()` with request_id grouping logic |
+| `claude_session_player/renderer.py` | Added `_render_assistant_text()` handler, added `ASSISTANT_TEXT` dispatch in `render()`, imported new dependencies |
+| `tests/test_formatter.py` | Added `TestFormatAssistantText` (7 tests), `TestToMarkdownRequestIdGrouping` (7 tests), updated `TestFormatElement` (replaced old placeholder test with 2 real tests) |
+| `tests/test_renderer.py` | Added `TestRenderAssistantText` (8 tests), `TestRenderAssistantTextIntegration` (3 tests) |
+
+## Model Changes
+
+- `AssistantText` gained a `request_id: str | None = None` field. This stores the `requestId` from the JSONL line so that `to_markdown()` can determine which elements belong to the same response group.
+
+## How Response Grouping Was Implemented
+
+The `to_markdown()` function was rewritten from a simple `"\n\n".join(parts)` to track `prev_request_id` across elements. The rule: insert a blank line separator between consecutive elements *unless* both share the same non-None `request_id`. This means:
+- Two `AssistantText` elements with `request_id="req_001"` → no blank line between them
+- `UserMessage` (no request_id) followed by `AssistantText` → blank line
+- Two `AssistantText` with `request_id=None` → blank line (None doesn't group)
+
+The `current_request_id` on `ScreenState` is set when rendering assistant text and reset to `None` when rendering user input. This enables future use for other assistant block types (thinking, tool_use) that share the same `requestId`.
+
+## Formatting Decisions
+
+- `format_assistant_text` mirrors `format_user_text` structure: first line gets `● ` prefix, continuation lines get 2-space indent
+- Empty text produces just `●` (no trailing space), consistent with the user text pattern
+- Markdown in assistant text is passed through verbatim — the output IS markdown
+
+## Test Results
+
+```
+132 passed in 0.59s
+```
+
+### Test Breakdown (27 new tests)
+- **test_formatter.py** (16 new): 7 format_assistant_text, 2 format_element (assistant), 7 to_markdown request_id grouping
+- **test_renderer.py** (11 new): 8 render assistant text, 3 render assistant text integration
+
+### Prior tests
+- 20 tests from Issue 01 (`test_models.py`) — all pass unchanged
+- 56 tests from Issue 02 (`test_parser.py`) — all pass unchanged
+- 30 tests from Issue 03 (`test_formatter.py` + `test_renderer.py`) — 1 updated (replaced `test_assistant_text_empty_for_now` with `test_assistant_text` and `test_assistant_text_with_request_id`)
+
+## Deviations from Spec
+
+- No `match/case` statements used — the system Python is 3.9 which doesn't support structural pattern matching. Used `if/elif` chains instead, consistent with Issue 03's approach.


### PR DESCRIPTION
## Summary
- Add `request_id` field to `AssistantText` dataclass for response grouping
- Implement `format_assistant_text()` with `●` prefix and 2-space indent continuation
- Rewrite `to_markdown()` to suppress blank lines between elements sharing the same `requestId`
- Add `_render_assistant_text()` dispatch in renderer

## Test plan
- [x] 27 new tests added (132 total, all passing)
- [x] Single/multi-line/empty assistant text formatting verified
- [x] Markdown passthrough (bold, lists, code blocks) verified
- [x] Same requestId grouping: no blank line between blocks
- [x] Different requestId: blank line separator
- [x] User input resets `current_request_id`
- [x] Full conversation integration tests (user → assistant → assistant → user → assistant)
- [x] All 106 prior tests from issues 01-03 still pass

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)