### PR TITLE
Issue #5: Tool Call Rendering & Abbreviation

### DIFF
--- a/claude_session_player/formatter.py
+++ b/claude_session_player/formatter.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .models import AssistantText, ScreenState, SystemOutput, UserMessage
+from .models import AssistantText, ScreenState, SystemOutput, ToolCall, UserMessage
 
 
 def format_user_text(text: str) -> str:
@@ -42,6 +42,14 @@ def format_element(element: object) -> str:
         return element.text
     if isinstance(element, AssistantText):
         return element.text
+    if isinstance(element, ToolCall):
+        line = f"\u25cf {element.tool_name}({element.label})"
+        if element.progress_text is not None:
+            line += f"\n  \u2514 {element.progress_text}"
+        if element.result is not None:
+            prefix = "  \u2717 " if element.is_error else "  \u2514 "
+            line += f"\n{prefix}{element.result}"
+        return line
     return ""
 
 

--- a/claude_session_player/models.py
+++ b/claude_session_player/models.py
@@ -31,6 +31,7 @@ class ToolCall:
     result: str | None = None
     is_error: bool = False
     progress_text: str | None = None
+    request_id: str | None = None
 
 
 @dataclass

--- a/claude_session_player/tools.py
+++ b/claude_session_player/tools.py
@@ -1,5 +1,36 @@
 """Tool-specific input abbreviation logic."""
 
+from __future__ import annotations
+
+
+def _truncate(text: str, max_len: int = 60) -> str:
+    """Truncate text to max_len chars, appending … if truncated."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "\u2026"
+
+
+def _basename(path: str) -> str:
+    """Extract basename from a file path."""
+    return path.rsplit("/", 1)[-1] if "/" in path else path
+
+
+# Tool name → (primary_field, fallback_field, transform)
+# transform: "truncate", "basename", or "fixed:value"
+_TOOL_RULES: dict[str, tuple[str, str | None, str]] = {
+    "Bash": ("description", "command", "truncate"),
+    "Read": ("file_path", None, "basename"),
+    "Write": ("file_path", None, "basename"),
+    "Edit": ("file_path", None, "basename"),
+    "Glob": ("pattern", None, "truncate"),
+    "Grep": ("pattern", None, "truncate"),
+    "Task": ("description", None, "truncate"),
+    "WebSearch": ("query", None, "truncate"),
+    "WebFetch": ("url", None, "truncate"),
+    "NotebookEdit": ("notebook_path", None, "basename"),
+    "TodoWrite": (None, None, "fixed:todos"),
+}
+
 
 def abbreviate_tool_input(tool_name: str, tool_input: dict) -> str:
     """Create a short display label for a tool invocation.
@@ -11,4 +42,27 @@ def abbreviate_tool_input(tool_name: str, tool_input: dict) -> str:
     Returns:
         Abbreviated string for display (max 60 chars).
     """
-    raise NotImplementedError("Implemented in issue 02")
+    rule = _TOOL_RULES.get(tool_name)
+    if rule is None:
+        return "\u2026"
+
+    primary_field, fallback_field, transform = rule
+
+    # Fixed value tools (e.g., TodoWrite → "todos")
+    if transform.startswith("fixed:"):
+        return transform[6:]
+
+    # Get the raw value from primary or fallback field
+    raw = ""
+    if primary_field is not None:
+        raw = tool_input.get(primary_field, "")
+    if not raw and fallback_field is not None:
+        raw = tool_input.get(fallback_field, "")
+    if not raw:
+        return "\u2026"
+
+    # Apply transform
+    if transform == "basename":
+        return _basename(raw)
+    # "truncate"
+    return _truncate(raw)

--- a/issues/worklogs/05-worklog.md
+++ b/issues/worklogs/05-worklog.md
@@ -1,0 +1,51 @@
+# Issue 05 Worklog: Tool Call Rendering & Abbreviation
+
+## Files Created/Modified
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/tools.py` | Full implementation: `abbreviate_tool_input()`, `_truncate()`, `_basename()`, table-driven rule dispatch for 11 known tools |
+| `claude_session_player/models.py` | Added `request_id: str \| None = None` field to `ToolCall` dataclass |
+| `claude_session_player/renderer.py` | Added `_render_tool_use()` handler, added `TOOL_USE` dispatch in `render()`, imported `ToolCall`, `get_tool_use_info`, `abbreviate_tool_input` |
+| `claude_session_player/formatter.py` | Added `ToolCall` handling in `format_element()` with progress_text and result rendering |
+| `tests/test_tools.py` | 31 tests across 7 test classes |
+| `tests/test_renderer.py` | Added 4 test classes (16 tests): `TestRenderToolUse`, `TestRenderToolUseParallel`, `TestRenderToolUseMarkdown`; updated `test_unhandled_types_pass` to use THINKING instead of TOOL_USE |
+| `tests/test_formatter.py` | Added 4 new tests: 2 `format_element` ToolCall tests, 2 `to_markdown` request_id grouping tests with ToolCall |
+
+## Decisions Made
+
+- **Table-driven abbreviation rules**: Used a `_TOOL_RULES` dict mapping tool name → `(primary_field, fallback_field, transform)` instead of a long if/elif chain. This is concise, easy to extend, and O(1) lookup.
+- **Transform types**: Three transforms: `"truncate"` (first 60 chars with `…`), `"basename"` (last path component), `"fixed:value"` (literal string). This covers all spec requirements cleanly.
+- **`NotebookEdit` added**: The issue spec includes `NotebookEdit` with basename extraction on `notebook_path`, which the main spec's tool table didn't list. Added it per the issue spec.
+- **`TodoWrite` returns fixed `"todos"`**: No field inspection needed — the issue spec says fixed string.
+- **Unknown tool → `…`**: Any tool not in `_TOOL_RULES` returns `…` (ellipsis), matching the spec's "Other" row.
+- **Missing/empty fields → `…`**: When the expected field is missing or empty, returns `…` as a graceful fallback.
+- **Updated unhandled type test**: The prior test `test_unhandled_types_pass` used `tool_use_line` to verify unhandled types don't add elements. Since TOOL_USE is now handled, changed it to use `thinking_line` instead.
+
+## Tool Abbreviation Edge Cases
+
+- Bash with empty description falls back to command field
+- Bash with both empty description and command returns `…`
+- Read/Write/Edit with no slash in path returns the path unchanged (already a basename)
+- TodoWrite ignores input dict entirely — always returns `"todos"`
+
+## Test Results
+
+```
+183 passed in 0.56s
+```
+
+### Test Breakdown (51 new tests)
+- **test_tools.py** (31 new): 4 truncate, 4 basename, 4 Bash, 5 file path tools, 3 pattern tools, 7 other tools, 4 edge cases
+- **test_renderer.py** (16 new): 8 render tool_use, 3 parallel tool calls, 5 markdown output
+- **test_formatter.py** (4 new): 2 format_element ToolCall, 2 to_markdown ToolCall grouping
+
+### Prior tests
+- 20 tests from Issue 01 (`test_models.py`) — all pass unchanged
+- 56 tests from Issue 02 (`test_parser.py`) — all pass unchanged
+- 30 tests from Issue 03+04 (`test_formatter.py` + `test_renderer.py`) — 1 updated (unhandled type test)
+
+## Deviations from Spec
+
+- No `match/case` statements used — the system Python is 3.9, consistent with Issues 03 and 04.
+- The issue spec mentions `_truncate` and `_basename` as standalone functions. These are implemented but also used internally by the table-driven `abbreviate_tool_input()`.

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from claude_session_player.models import AssistantText, ScreenState, SystemOutput, UserMessage
+from claude_session_player.models import AssistantText, ScreenState, SystemOutput, ToolCall, UserMessage
 from claude_session_player.renderer import render
 
 
@@ -317,8 +317,198 @@ class TestRenderIntegration:
         assert "❯ hello world" in md
         assert "git status output here" in md
 
-    def test_unhandled_types_pass(self, empty_state: ScreenState, tool_use_line: dict) -> None:
-        """Unhandled types (e.g., TOOL_USE) don't crash and don't add elements."""
-        result = render(empty_state, tool_use_line)
+    def test_unhandled_types_pass(self, empty_state: ScreenState, thinking_line: dict) -> None:
+        """Unhandled types (e.g., THINKING) don't crash and don't add elements."""
+        result = render(empty_state, thinking_line)
         assert result is empty_state
         assert len(result.elements) == 0
+
+
+class TestRenderToolUse:
+    """Tests for rendering tool_use assistant blocks."""
+
+    def test_single_tool_use(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        result = render(empty_state, tool_use_line)
+        assert len(result.elements) == 1
+        assert isinstance(result.elements[0], ToolCall)
+        assert result.elements[0].tool_name == "Bash"
+        assert result.elements[0].label == "List files"
+
+    def test_tool_use_id_stored(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        render(empty_state, tool_use_line)
+        assert empty_state.elements[0].tool_use_id == "toolu_001"
+
+    def test_tool_call_registered(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        render(empty_state, tool_use_line)
+        assert "toolu_001" in empty_state.tool_calls
+        assert empty_state.tool_calls["toolu_001"] == 0
+
+    def test_request_id_set(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        render(empty_state, tool_use_line)
+        assert empty_state.current_request_id == "req_001"
+        assert empty_state.elements[0].request_id == "req_001"
+
+    def test_read_tool_basename(self, empty_state: ScreenState, tool_use_read_line: dict) -> None:
+        render(empty_state, tool_use_read_line)
+        assert empty_state.elements[0].label == "main.py"
+
+    def test_write_tool_basename(self, empty_state: ScreenState, tool_use_write_line: dict) -> None:
+        render(empty_state, tool_use_write_line)
+        assert empty_state.elements[0].label == "config.py"
+
+    def test_tool_call_index_after_other_elements(self, empty_state: ScreenState) -> None:
+        """Tool call registered at correct index when other elements precede it."""
+        user_line = {
+            "type": "user",
+            "isMeta": False,
+            "message": {"role": "user", "content": "hello"},
+        }
+        tool_line = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_099", "name": "Bash", "input": {"command": "ls"}}],
+            },
+        }
+        render(empty_state, user_line)
+        render(empty_state, tool_line)
+        assert empty_state.tool_calls["toolu_099"] == 1
+
+    def test_markdown_output(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        render(empty_state, tool_use_line)
+        md = empty_state.to_markdown()
+        assert md == "\u25cf Bash(List files)"
+
+
+class TestRenderToolUseParallel:
+    """Tests for parallel tool calls with same requestId."""
+
+    def test_two_parallel_tools_no_blank_line(self, empty_state: ScreenState) -> None:
+        """Two tool_use blocks with same requestId → no blank line between."""
+        line1 = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_A", "name": "Bash", "input": {"command": "ls"}}],
+            },
+        }
+        line2 = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_B", "name": "Read", "input": {"file_path": "/a/b.py"}}],
+            },
+        }
+        render(empty_state, line1)
+        render(empty_state, line2)
+        assert len(empty_state.elements) == 2
+        assert empty_state.tool_calls["toolu_A"] == 0
+        assert empty_state.tool_calls["toolu_B"] == 1
+        md = empty_state.to_markdown()
+        assert md == "\u25cf Bash(ls)\n\u25cf Read(b.py)"
+
+    def test_text_then_tool_same_rid_no_blank(self, empty_state: ScreenState) -> None:
+        """AssistantText then tool_use with same requestId → no blank line."""
+        text_line = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Let me check."}],
+            },
+        }
+        tool_line = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_C", "name": "Bash", "input": {"command": "ls"}}],
+            },
+        }
+        render(empty_state, text_line)
+        render(empty_state, tool_line)
+        md = empty_state.to_markdown()
+        assert md == "\u25cf Let me check.\n\u25cf Bash(ls)"
+
+    def test_tool_use_new_rid_blank_line(self, empty_state: ScreenState) -> None:
+        """Tool_use with new requestId after previous → blank line."""
+        line1 = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_D", "name": "Bash", "input": {"command": "ls"}}],
+            },
+        }
+        line2 = {
+            "type": "assistant",
+            "requestId": "req_002",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_E", "name": "Read", "input": {"file_path": "/x.py"}}],
+            },
+        }
+        render(empty_state, line1)
+        render(empty_state, line2)
+        md = empty_state.to_markdown()
+        assert md == "\u25cf Bash(ls)\n\n\u25cf Read(x.py)"
+
+
+class TestRenderToolUseMarkdown:
+    """Tests for ToolCall markdown output format."""
+
+    def test_tool_call_without_result(self, empty_state: ScreenState, tool_use_line: dict) -> None:
+        render(empty_state, tool_use_line)
+        md = empty_state.to_markdown()
+        assert md == "\u25cf Bash(List files)"
+        assert "\u2514" not in md
+
+    def test_tool_call_with_result(self) -> None:
+        """Preview: tool call with result set produces └ line."""
+        from claude_session_player.formatter import format_element
+
+        tc = ToolCall(tool_name="Bash", tool_use_id="t1", label="ls", result="file1.py\nfile2.py")
+        formatted = format_element(tc)
+        assert "\u25cf Bash(ls)" in formatted
+        assert "  \u2514 file1.py\nfile2.py" in formatted
+
+    def test_tool_call_with_error_result(self) -> None:
+        """Preview: tool call with error result produces ✗ line."""
+        from claude_session_player.formatter import format_element
+
+        tc = ToolCall(tool_name="Bash", tool_use_id="t1", label="bad", result="not found", is_error=True)
+        formatted = format_element(tc)
+        assert "\u25cf Bash(bad)" in formatted
+        assert "  \u2717 not found" in formatted
+
+    def test_tool_call_with_progress(self) -> None:
+        """Preview: tool call with progress_text produces └ line."""
+        from claude_session_player.formatter import format_element
+
+        tc = ToolCall(tool_name="Bash", tool_use_id="t1", label="running", progress_text="50%")
+        formatted = format_element(tc)
+        assert "\u25cf Bash(running)" in formatted
+        assert "  \u2514 50%" in formatted
+
+    def test_user_then_tool_call_markdown(self, empty_state: ScreenState) -> None:
+        """User → tool call produces correct markdown spacing."""
+        user_line = {
+            "type": "user",
+            "isMeta": False,
+            "message": {"role": "user", "content": "do something"},
+        }
+        tool_line = {
+            "type": "assistant",
+            "requestId": "req_001",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_F", "name": "Bash", "input": {"command": "echo hi"}}],
+            },
+        }
+        render(empty_state, user_line)
+        render(empty_state, tool_line)
+        md = empty_state.to_markdown()
+        assert md == "\u276f do something\n\n\u25cf Bash(echo hi)"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,173 @@
+"""Tests for tool input abbreviation logic."""
+
+from __future__ import annotations
+
+from claude_session_player.tools import _basename, _truncate, abbreviate_tool_input
+
+
+class TestTruncate:
+    """Tests for the _truncate helper."""
+
+    def test_short_text(self) -> None:
+        assert _truncate("hello") == "hello"
+
+    def test_exact_60(self) -> None:
+        text = "a" * 60
+        assert _truncate(text) == text
+
+    def test_61_chars_truncated(self) -> None:
+        text = "a" * 61
+        result = _truncate(text)
+        assert len(result) == 60
+        assert result.endswith("\u2026")
+
+    def test_long_text(self) -> None:
+        text = "x" * 100
+        result = _truncate(text)
+        assert len(result) == 60
+        assert result == "x" * 59 + "\u2026"
+
+
+class TestBasename:
+    """Tests for the _basename helper."""
+
+    def test_full_path(self) -> None:
+        assert _basename("/Users/agutnikov/work/project/README.md") == "README.md"
+
+    def test_basename_only(self) -> None:
+        assert _basename("README.md") == "README.md"
+
+    def test_relative_path(self) -> None:
+        assert _basename("src/main.py") == "main.py"
+
+    def test_trailing_slash(self) -> None:
+        # Edge case: trailing slash gives empty string
+        assert _basename("src/") == ""
+
+
+class TestAbbreviateBash:
+    """Tests for Bash tool abbreviation."""
+
+    def test_with_description(self) -> None:
+        result = abbreviate_tool_input("Bash", {
+            "command": "rm -rf node_modules",
+            "description": "Remove node_modules and build artifacts",
+        })
+        assert result == "Remove node_modules and build artifacts"
+
+    def test_without_description(self) -> None:
+        result = abbreviate_tool_input("Bash", {
+            "command": "git status && git diff HEAD",
+        })
+        assert result == "git status && git diff HEAD"
+
+    def test_long_command_truncated(self) -> None:
+        long_cmd = "find . -name '*.py' -exec grep -l 'TODO' {} \\; | sort | uniq -c | sort -rn | head -20"
+        result = abbreviate_tool_input("Bash", {"command": long_cmd})
+        assert len(result) == 60
+        assert result.endswith("\u2026")
+
+    def test_long_description_truncated(self) -> None:
+        long_desc = "Remove all temporary files and build artifacts from the project directory tree recursively"
+        result = abbreviate_tool_input("Bash", {
+            "command": "rm -rf tmp/",
+            "description": long_desc,
+        })
+        assert len(result) == 60
+        assert result.endswith("\u2026")
+
+
+class TestAbbreviateFilePaths:
+    """Tests for Read, Write, Edit, NotebookEdit basename extraction."""
+
+    def test_read_full_path(self) -> None:
+        result = abbreviate_tool_input("Read", {"file_path": "/Users/user/project/README.md"})
+        assert result == "README.md"
+
+    def test_read_basename_only(self) -> None:
+        result = abbreviate_tool_input("Read", {"file_path": "README.md"})
+        assert result == "README.md"
+
+    def test_write_path(self) -> None:
+        result = abbreviate_tool_input("Write", {"file_path": "/src/config.py", "content": "x = 1"})
+        assert result == "config.py"
+
+    def test_edit_path(self) -> None:
+        result = abbreviate_tool_input("Edit", {"file_path": "/a/b/c/models.py"})
+        assert result == "models.py"
+
+    def test_notebook_edit_path(self) -> None:
+        result = abbreviate_tool_input("NotebookEdit", {"notebook_path": "/home/user/analysis.ipynb"})
+        assert result == "analysis.ipynb"
+
+
+class TestAbbreviatePatterns:
+    """Tests for Glob, Grep pattern abbreviation."""
+
+    def test_glob_pattern(self) -> None:
+        result = abbreviate_tool_input("Glob", {"pattern": "**/*.ts"})
+        assert result == "**/*.ts"
+
+    def test_grep_pattern(self) -> None:
+        result = abbreviate_tool_input("Grep", {"pattern": "TODO"})
+        assert result == "TODO"
+
+    def test_grep_long_pattern_truncated(self) -> None:
+        long_pattern = "very_long_function_name_that_exceeds_the_sixty_character_limit_for_display"
+        result = abbreviate_tool_input("Grep", {"pattern": long_pattern})
+        assert len(result) == 60
+        assert result.endswith("\u2026")
+
+
+class TestAbbreviateOtherTools:
+    """Tests for Task, WebSearch, WebFetch, TodoWrite, unknown."""
+
+    def test_task_description(self) -> None:
+        result = abbreviate_tool_input("Task", {"description": "Explore codebase structure"})
+        assert result == "Explore codebase structure"
+
+    def test_task_long_description(self) -> None:
+        long_desc = "Explore the entire codebase structure and identify all modules that need refactoring"
+        result = abbreviate_tool_input("Task", {"description": long_desc})
+        assert len(result) == 60
+        assert result.endswith("\u2026")
+
+    def test_websearch_query(self) -> None:
+        result = abbreviate_tool_input("WebSearch", {"query": "Claude hooks 2026"})
+        assert result == "Claude hooks 2026"
+
+    def test_webfetch_url(self) -> None:
+        result = abbreviate_tool_input("WebFetch", {"url": "https://example.com/docs"})
+        assert result == "https://example.com/docs"
+
+    def test_todowrite_fixed(self) -> None:
+        result = abbreviate_tool_input("TodoWrite", {"todos": [{"content": "item"}]})
+        assert result == "todos"
+
+    def test_todowrite_empty_input(self) -> None:
+        result = abbreviate_tool_input("TodoWrite", {})
+        assert result == "todos"
+
+    def test_unknown_tool(self) -> None:
+        result = abbreviate_tool_input("SomeNewTool", {"foo": "bar"})
+        assert result == "\u2026"
+
+
+class TestAbbreviateEdgeCases:
+    """Tests for edge cases in abbreviation."""
+
+    def test_empty_input_dict(self) -> None:
+        result = abbreviate_tool_input("Bash", {})
+        assert result == "\u2026"
+
+    def test_missing_expected_field(self) -> None:
+        result = abbreviate_tool_input("Read", {"some_other_field": "value"})
+        assert result == "\u2026"
+
+    def test_empty_string_field(self) -> None:
+        result = abbreviate_tool_input("Bash", {"command": "", "description": ""})
+        assert result == "\u2026"
+
+    def test_bash_empty_description_falls_back(self) -> None:
+        result = abbreviate_tool_input("Bash", {"command": "ls", "description": ""})
+        assert result == "ls"


### PR DESCRIPTION
## Summary
- Implements `abbreviate_tool_input()` with table-driven rules for 11 known tools (Bash, Read, Write, Edit, Glob, Grep, Task, WebSearch, WebFetch, NotebookEdit, TodoWrite)
- Adds `_render_tool_use()` dispatch that creates `ToolCall` elements, registers them in `state.tool_calls`, and sets `request_id` for grouping
- Updates `format_element()` to render `ToolCall` as `● ToolName(label)` with optional progress/result lines

## Test plan
- [x] 31 abbreviation tests covering all tool types, truncation, basename, edge cases
- [x] 16 renderer tests for tool_use rendering, parallel tools, request_id grouping
- [x] 4 formatter tests for ToolCall format_element and to_markdown grouping
- [x] All 183 tests passing (132 prior + 51 new)
- [x] Prior tests unchanged (1 updated: unhandled type test uses THINKING instead of TOOL_USE)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)