### PR TITLE
Issue #7: Thinking, Turn Duration & System Messages

### DIFF
--- a/claude_session_player/formatter.py
+++ b/claude_session_player/formatter.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
-from .models import AssistantText, ScreenState, SystemOutput, ToolCall, UserMessage
+from .models import AssistantText, ScreenState, SystemOutput, ThinkingIndicator, ToolCall, TurnDuration, UserMessage
+
+
+def format_duration(ms: int) -> str:
+    """Format milliseconds as human-readable duration.
+
+    Args:
+        ms: Duration in milliseconds.
+
+    Returns:
+        Formatted string like "5s" or "1m 28s".
+    """
+    total_seconds = ms // 1000
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    minutes = total_seconds // 60
+    seconds = total_seconds % 60
+    return f"{minutes}m {seconds}s"
 
 
 def truncate_result(text: str, max_lines: int = 5) -> str:
@@ -73,6 +90,10 @@ def format_element(element: object) -> str:
             for result_line in result_lines[1:]:
                 line += f"\n    {result_line}"
         return line
+    if isinstance(element, ThinkingIndicator):
+        return "\u2731 Thinking\u2026"
+    if isinstance(element, TurnDuration):
+        return f"\u2731 Crunched for {format_duration(element.duration_ms)}"
     return ""
 
 

--- a/claude_session_player/models.py
+++ b/claude_session_player/models.py
@@ -38,7 +38,7 @@ class ToolCall:
 class ThinkingIndicator:
     """Thinking block. Rendered as ✱ Thinking…"""
 
-    pass
+    request_id: str | None = None
 
 
 @dataclass

--- a/issues/worklogs/07-worklog.md
+++ b/issues/worklogs/07-worklog.md
@@ -1,0 +1,82 @@
+# Issue 07 Worklog: Thinking, Turn Duration & System Messages
+
+## Files Modified
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/models.py` | Added `request_id: str \| None = None` field to `ThinkingIndicator` dataclass |
+| `claude_session_player/formatter.py` | Added `format_duration()` helper, updated `format_element()` for `ThinkingIndicator` and `TurnDuration` |
+| `claude_session_player/renderer.py` | Added `_render_thinking()`, `_render_turn_duration()`, `_render_compact_boundary()` handlers and dispatch |
+| `tests/test_formatter.py` | Added `TestFormatDuration` (7 tests), 4 new `format_element` tests, 1 request_id grouping test |
+| `tests/test_renderer.py` | Added `TestRenderThinking` (5 tests), `TestRenderTurnDuration` (5 tests), `TestRenderCompactBoundary` (5 tests); updated 1 existing test |
+
+## Model Changes
+
+- `ThinkingIndicator` gained a `request_id: str | None = None` field. This enables thinking blocks to participate in request_id-based grouping with other assistant blocks (text, tool_use) so that `thinking → text` with the same requestId renders with no blank line between them.
+
+## Duration Formatting Edge Cases
+
+The `format_duration()` function handles:
+- `0ms` → `"0s"`
+- `5000ms` → `"5s"` (seconds only for < 60s)
+- `59999ms` → `"59s"` (truncates to whole seconds, boundary case)
+- `60000ms` → `"1m 0s"` (exact minute)
+- `65000ms` → `"1m 5s"` (minutes and seconds)
+- `88947ms` → `"1m 28s"` (real-world example from spec)
+- `120000ms` → `"2m 0s"` (multiple minutes)
+
+The implementation uses integer division (`//`) throughout to avoid floating-point edge cases.
+
+## Render Dispatch Logic
+
+Three new cases added to the main `render()` function:
+
+```python
+elif line_type is LineType.THINKING:
+    _render_thinking(state, line)
+elif line_type is LineType.TURN_DURATION:
+    _render_turn_duration(state, line)
+elif line_type is LineType.COMPACT_BOUNDARY:
+    _render_compact_boundary(state)
+```
+
+### Thinking Handler
+- Extracts `request_id` from line
+- Creates `ThinkingIndicator(request_id=request_id)`
+- Appends to elements and sets `current_request_id`
+
+### Turn Duration Handler
+- Extracts `duration_ms` using `get_duration_ms()` from parser
+- Creates `TurnDuration(duration_ms=duration_ms)`
+- Appends to elements and resets `current_request_id = None`
+
+### Compact Boundary Handler
+- Simply calls `state.clear()` which was already implemented in Issue 01
+- This clears `elements`, `tool_calls`, and resets `current_request_id`
+
+## Test Results
+
+```
+238 passed in 0.69s
+```
+
+### New Tests (27 tests)
+- **TestFormatDuration** (7 tests): zero, seconds, boundary cases, minutes+seconds
+- **TestFormatElement** (4 new): thinking_indicator, thinking_indicator_with_request_id, turn_duration_seconds, turn_duration_minutes
+- **TestToMarkdownRequestIdGrouping** (1 new): thinking_and_text_same_rid_no_blank
+- **TestRenderThinking** (5 tests): creates element, has request_id, sets current_request_id, markdown output, thinking→text grouping
+- **TestRenderTurnDuration** (5 tests): creates element, resets request_id, markdown seconds, markdown minutes, full user→assistant→duration flow
+- **TestRenderCompactBoundary** (5 tests): clears elements, clears tool_calls, resets request_id, messages after compaction rendered, full state cleared
+
+### Prior Tests
+- 211 tests from Issues 01-06 — all pass (2 tests updated to reflect new behavior)
+
+## Updated Tests
+
+1. `TestFormatElement.test_unknown_element`: Changed from using `ThinkingIndicator()` (which is now handled) to using a plain `object()` to test the unknown element fallback.
+
+2. `TestRenderIntegration.test_unhandled_types_pass`: Changed from using `thinking_line` (which is now handled) to using `system_local_command_line` (which maps to INVISIBLE).
+
+## Deviations from Spec
+
+- No `match/case` statements used — consistent with Issues 03-06, the system Python is 3.9 which doesn't support structural pattern matching. Used `if/elif` chains instead.


### PR DESCRIPTION
## Summary

Implement rendering for three assistant/system message types:

- **Thinking blocks**: Show `✱ Thinking…` (fixed text, raw thinking not displayed)
- **Turn duration**: Show `✱ Crunched for Xm Ys` with formatted time
- **Compact boundary**: Clear all state (conversation restart after compaction)

## Changes

- Add `request_id` field to `ThinkingIndicator` dataclass for response grouping
- Add `format_duration()` helper for milliseconds → human-readable formatting
- Add render handlers for `THINKING`, `TURN_DURATION`, `COMPACT_BOUNDARY`
- Update `format_element()` to handle `ThinkingIndicator` and `TurnDuration`
- 27 new tests (238 total, all passing)

## Test plan

- [ ] Thinking block renders as `✱ Thinking…` with request_id grouping
- [ ] Turn duration formatted correctly for all time ranges (0s, 5s, 59s, 1m 0s, 1m 28s)
- [ ] Compact boundary clears all state (elements, tool_calls, current_request_id)
- [ ] Thinking → text with same requestId has no blank line between
- [ ] All prior tests still pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)