### PR TITLE
Issue #8: Progress Message Rendering

### DIFF
--- a/claude_session_player/formatter.py
+++ b/claude_session_player/formatter.py
@@ -80,8 +80,7 @@ def format_element(element: object) -> str:
         return element.text
     if isinstance(element, ToolCall):
         line = f"\u25cf {element.tool_name}({element.label})"
-        if element.progress_text is not None:
-            line += f"\n  \u2514 {element.progress_text}"
+        # Result takes priority over progress (result is the final state)
         if element.result is not None:
             prefix = "  \u2717 " if element.is_error else "  \u2514 "
             result_lines = element.result.split("\n")
@@ -89,6 +88,8 @@ def format_element(element: object) -> str:
             # Subsequent lines indented with 4 spaces to align with text after └/✗
             for result_line in result_lines[1:]:
                 line += f"\n    {result_line}"
+        elif element.progress_text is not None:
+            line += f"\n  \u2514 {element.progress_text}"
         return line
     if isinstance(element, ThinkingIndicator):
         return "\u2731 Thinking\u2026"

--- a/claude_session_player/parser.py
+++ b/claude_session_player/parser.py
@@ -273,9 +273,12 @@ def get_progress_data(line: dict) -> dict:
 
 
 def get_parent_tool_use_id(line: dict) -> str | None:
-    """Extract parentToolUseID from a progress message."""
-    data = line.get("data") or {}
-    return data.get("parentToolUseID")
+    """Extract parentToolUseID from a progress message.
+
+    parentToolUseID is at the top level of the progress message,
+    not inside the data dict.
+    """
+    return line.get("parentToolUseID")
 
 
 def get_local_command_text(line: dict) -> str:

--- a/claude_session_player/renderer.py
+++ b/claude_session_player/renderer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .formatter import format_assistant_text, format_user_text, truncate_result
 from .models import AssistantText, ScreenState, SystemOutput, ThinkingIndicator, ToolCall, TurnDuration, UserMessage
-from .parser import LineType, classify_line, get_duration_ms, get_local_command_text, get_request_id, get_tool_result_info, get_tool_use_info, get_user_text
+from .parser import LineType, classify_line, get_duration_ms, get_local_command_text, get_parent_tool_use_id, get_progress_data, get_request_id, get_tool_result_info, get_tool_use_info, get_user_text
 from .tools import abbreviate_tool_input
 
 
@@ -36,7 +36,19 @@ def render(state: ScreenState, line: dict) -> ScreenState:
         _render_turn_duration(state, line)
     elif line_type is LineType.COMPACT_BOUNDARY:
         _render_compact_boundary(state)
-    # INVISIBLE and unhandled types: do nothing (future issues add more cases)
+    elif line_type is LineType.BASH_PROGRESS:
+        _render_bash_progress(state, line)
+    elif line_type is LineType.HOOK_PROGRESS:
+        _render_hook_progress(state, line)
+    elif line_type is LineType.AGENT_PROGRESS:
+        _render_agent_progress(state, line)
+    elif line_type is LineType.QUERY_UPDATE:
+        _render_query_update(state, line)
+    elif line_type is LineType.SEARCH_RESULTS:
+        _render_search_results(state, line)
+    elif line_type is LineType.WAITING_FOR_TASK:
+        _render_waiting_for_task(state, line)
+    # INVISIBLE and unhandled types: do nothing
 
     return state
 
@@ -134,3 +146,96 @@ def _render_turn_duration(state: ScreenState, line: dict) -> None:
 def _render_compact_boundary(state: ScreenState) -> None:
     """Handle compact boundary by clearing all state."""
     state.clear()
+
+
+# ---------------------------------------------------------------------------
+# Progress message handlers
+# ---------------------------------------------------------------------------
+
+
+def _get_bash_progress_text(data: dict) -> str:
+    """Extract the last non-empty line from bash progress fullOutput.
+
+    Truncates to 76 chars to fit within 80 cols with the `  └ ` prefix.
+    """
+    full_output = data.get("fullOutput", "")
+    lines = [line for line in full_output.split("\n") if line.strip()]
+    if not lines:
+        return "running…"
+    last_line = lines[-1]
+    if len(last_line) > 76:
+        return last_line[:75] + "…"
+    return last_line
+
+
+def _update_tool_call_progress(state: ScreenState, parent_id: str | None, progress_text: str) -> bool:
+    """Update progress_text on matching tool call.
+
+    Returns True if a match was found, False otherwise.
+    """
+    if parent_id and parent_id in state.tool_calls:
+        index = state.tool_calls[parent_id]
+        element = state.elements[index]
+        if isinstance(element, ToolCall):
+            element.progress_text = progress_text
+            return True
+    return False
+
+
+def _render_bash_progress(state: ScreenState, line: dict) -> None:
+    """Render bash_progress: update ToolCall with last line of fullOutput."""
+    data = get_progress_data(line)
+    parent_id = get_parent_tool_use_id(line)
+    progress_text = _get_bash_progress_text(data)
+    _update_tool_call_progress(state, parent_id, progress_text)
+
+
+def _render_hook_progress(state: ScreenState, line: dict) -> None:
+    """Render hook_progress: update ToolCall with Hook: {hookName}."""
+    data = get_progress_data(line)
+    parent_id = get_parent_tool_use_id(line)
+    hook_name = data.get("hookName", "")
+    progress_text = f"Hook: {hook_name}"
+    _update_tool_call_progress(state, parent_id, progress_text)
+
+
+def _render_agent_progress(state: ScreenState, line: dict) -> None:
+    """Render agent_progress: update ToolCall with fixed 'Agent: working…'."""
+    parent_id = get_parent_tool_use_id(line)
+    progress_text = "Agent: working…"
+    _update_tool_call_progress(state, parent_id, progress_text)
+
+
+def _render_query_update(state: ScreenState, line: dict) -> None:
+    """Render query_update: update ToolCall with Searching: {query}."""
+    data = get_progress_data(line)
+    parent_id = get_parent_tool_use_id(line)
+    query = data.get("query", "")
+    progress_text = f"Searching: {query}"
+    _update_tool_call_progress(state, parent_id, progress_text)
+
+
+def _render_search_results(state: ScreenState, line: dict) -> None:
+    """Render search_results_received: update ToolCall with {resultCount} results."""
+    data = get_progress_data(line)
+    parent_id = get_parent_tool_use_id(line)
+    result_count = data.get("resultCount", 0)
+    progress_text = f"{result_count} results"
+    _update_tool_call_progress(state, parent_id, progress_text)
+
+
+def _render_waiting_for_task(state: ScreenState, line: dict) -> None:
+    """Render waiting_for_task: update ToolCall or create standalone SystemOutput.
+
+    If parentToolUseID matches a tool call, update that tool call's progress.
+    Otherwise, create a standalone SystemOutput element.
+    """
+    data = get_progress_data(line)
+    parent_id = get_parent_tool_use_id(line)
+    description = data.get("taskDescription", "")
+    progress_text = f"Waiting: {description}"
+
+    matched = _update_tool_call_progress(state, parent_id, progress_text)
+    if not matched:
+        # No matching tool call - render as standalone SystemOutput
+        state.elements.append(SystemOutput(text=f"└ {progress_text}"))

--- a/issues/worklogs/08-worklog.md
+++ b/issues/worklogs/08-worklog.md
@@ -1,0 +1,96 @@
+# Issue 08 Worklog: Progress Message Rendering
+
+## Files Modified
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/parser.py` | Fixed `get_parent_tool_use_id()` to extract from top-level (not `data` dict) |
+| `claude_session_player/renderer.py` | Added 6 progress render handlers, helper functions for progress text extraction |
+| `claude_session_player/formatter.py` | Fixed `format_element()` to show result over progress (result takes priority) |
+| `tests/conftest.py` | Updated all 6 progress fixtures to match real data format, added `waiting_for_task_no_parent_line` fixture |
+| `tests/test_parser.py` | Fixed `TestGetProgressData` test to match new fixture format |
+| `tests/test_renderer.py` | Added 18 new tests across 9 test classes for progress rendering |
+
+## Key Findings: Real Data vs Spec
+
+### parentToolUseID Location
+
+The issue spec examples and real data show `parentToolUseID` at the **top level** of the progress message, not inside the `data` dict:
+
+```json
+{
+  "type": "progress",
+  "data": { "type": "bash_progress", "fullOutput": "..." },
+  "toolUseID": "bash-progress-0",
+  "parentToolUseID": "toolu_01HqccoujvbFF2QgwjUyyqQA"  // Top level!
+}
+```
+
+The original `get_parent_tool_use_id()` in parser.py looked inside `data`. Fixed it to look at the top level.
+
+### Progress Types Implemented
+
+All 6 progress types from the spec are now handled:
+
+| Type | Progress Text | Source |
+|------|--------------|--------|
+| `bash_progress` | Last non-empty line of `fullOutput` | Truncated to 76 chars |
+| `hook_progress` | `Hook: {hookName}` | `data.hookName` |
+| `agent_progress` | `Agent: working…` | Fixed text |
+| `query_update` | `Searching: {query}` | `data.query` |
+| `search_results_received` | `{resultCount} results` | `data.resultCount` |
+| `waiting_for_task` | `Waiting: {taskDescription}` | `data.taskDescription` |
+
+## Design Decisions
+
+### Result Priority Over Progress
+
+The `format_element()` function was updated so that `result` takes priority over `progress_text`. If both are set, only the result is shown in the markdown output. This matches the spec requirement that "result is the final state."
+
+```python
+# Result takes priority over progress (result is the final state)
+if element.result is not None:
+    # Show result
+elif element.progress_text is not None:
+    # Show progress only if no result yet
+```
+
+### waiting_for_task Without Tool Matching
+
+When `waiting_for_task` has no `parentToolUseID` (or the ID doesn't match any tool call), it renders as a standalone `SystemOutput`:
+
+```
+└ Waiting: Explore codebase structure
+```
+
+This handles the case mentioned in the spec where `waiting_for_task` may not have a parent.
+
+### bash_progress Empty/Whitespace Output
+
+When `fullOutput` is empty or contains only whitespace lines, the progress text defaults to `running…` rather than an empty string.
+
+## Test Results
+
+```
+257 passed in 0.64s
+```
+
+### New Tests (18 tests)
+
+- **TestRenderBashProgress** (5 tests): updates tool call, unknown parent ignored, empty fullOutput, long line truncated, multiline takes last
+- **TestRenderHookProgress** (1 test): Hook: {hookName}
+- **TestRenderAgentProgress** (1 test): fixed Agent: working… text
+- **TestRenderQueryUpdate** (1 test): Searching: {query}
+- **TestRenderSearchResults** (1 test): {count} results
+- **TestRenderWaitingForTask** (3 tests): matching parent, no parent creates SystemOutput, unknown parent creates SystemOutput
+- **TestProgressOverwrites** (1 test): last progress wins
+- **TestProgressVsResultPriority** (3 tests): progress only, result priority, no progress no result
+- **TestProgressFullFlow** (2 tests): full flow with result, hook progress then result
+
+### Prior Tests
+
+- 238 tests from Issues 01-07 — 1 test updated (`TestGetProgressData` to match new fixture format)
+
+## Deviations from Spec
+
+- The spec shows `match/case` syntax but the system Python is 3.9 which doesn't support structural pattern matching. Used `if/elif` chains instead, consistent with Issues 03-07.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,78 +260,100 @@ def system_local_command_line() -> dict:
 
 @pytest.fixture
 def bash_progress_line() -> dict:
+    """Bash progress with fullOutput field (per issue spec)."""
     return {
         "type": "progress",
         "data": {
             "type": "bash_progress",
-            "parentToolUseID": "toolu_001",
-            "toolUseID": "bash-progress-0",
-            "content": "running...",
+            "output": "",
+            "fullOutput": "Building...\nStep 1/12: FROM python:3.11-slim",
+            "elapsedTimeSeconds": 2,
+            "totalLines": 0,
         },
+        "toolUseID": "bash-progress-0",
+        "parentToolUseID": "toolu_001",
     }
 
 
 @pytest.fixture
 def hook_progress_line() -> dict:
+    """Hook progress with hookName and hookEvent fields."""
     return {
         "type": "progress",
         "data": {
             "type": "hook_progress",
-            "parentToolUseID": "toolu_002",
-            "toolUseID": "hook-progress-0",
-            "hookName": "pre-commit",
+            "hookEvent": "PostToolUse",
+            "hookName": "PostToolUse:Read",
+            "command": "callback",
         },
+        "parentToolUseID": "toolu_002",
+        "toolUseID": "toolu_002",
     }
 
 
 @pytest.fixture
 def agent_progress_line() -> dict:
+    """Agent progress (fixed text output)."""
     return {
         "type": "progress",
         "data": {
             "type": "agent_progress",
-            "parentToolUseID": "toolu_003",
-            "toolUseID": "agent-progress-0",
-            "content": "working...",
         },
+        "toolUseID": "agent-progress-0",
+        "parentToolUseID": "toolu_003",
     }
 
 
 @pytest.fixture
 def query_update_line() -> dict:
+    """WebSearch query update progress."""
     return {
         "type": "progress",
         "data": {
             "type": "query_update",
-            "parentToolUseID": "toolu_004",
-            "toolUseID": "query-update-0",
-            "query": "Claude hooks 2026",
+            "query": "Claude Code hooks feature 2026",
         },
+        "parentToolUseID": "toolu_004",
     }
 
 
 @pytest.fixture
 def search_results_line() -> dict:
+    """WebSearch results received progress."""
     return {
         "type": "progress",
         "data": {
             "type": "search_results_received",
-            "parentToolUseID": "toolu_004",
-            "toolUseID": "search-results-0",
-            "resultCount": 5,
+            "resultCount": 10,
+            "query": "Claude Code hooks feature 2026",
         },
+        "parentToolUseID": "toolu_004",
     }
 
 
 @pytest.fixture
 def waiting_for_task_line() -> dict:
+    """Waiting for task progress with taskDescription."""
     return {
         "type": "progress",
         "data": {
             "type": "waiting_for_task",
-            "parentToolUseID": "toolu_005",
-            "toolUseID": "waiting-0",
-            "taskDescription": "Explore codebase",
+            "taskDescription": "Debug socat bridge from inside Docker container",
+            "taskType": "local_bash",
+        },
+        "parentToolUseID": "toolu_005",
+    }
+
+
+@pytest.fixture
+def waiting_for_task_no_parent_line() -> dict:
+    """Waiting for task without parentToolUseID (standalone)."""
+    return {
+        "type": "progress",
+        "data": {
+            "type": "waiting_for_task",
+            "taskDescription": "Explore codebase structure",
+            "taskType": "local_bash",
         },
     }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -273,7 +273,8 @@ class TestGetProgressData:
     def test_returns_data(self, bash_progress_line: dict) -> None:
         data = get_progress_data(bash_progress_line)
         assert data["type"] == "bash_progress"
-        assert data["parentToolUseID"] == "toolu_001"
+        # Note: parentToolUseID is at the top level, not in data
+        assert "fullOutput" in data  # bash_progress has fullOutput in data
 
 
 class TestGetParentToolUseId:


### PR DESCRIPTION
## Summary
- Implement rendering of all 6 progress message types (bash_progress, hook_progress, agent_progress, query_update, search_results_received, waiting_for_task)
- Progress messages update corresponding ToolCall via parentToolUseID matching
- Result takes priority over progress_text in format_element
- waiting_for_task without matching tool call renders as standalone SystemOutput
- Fix get_parent_tool_use_id() to extract from top-level (matching real data format)

## Test plan
- [x] bash_progress with valid parentToolUseID updates ToolCall.progress_text
- [x] bash_progress with unknown parentToolUseID is ignored
- [x] bash_progress extracts last non-empty line, truncated to 76 chars
- [x] hook_progress → Hook: {hookName}
- [x] agent_progress → fixed "Agent: working…"
- [x] query_update → Searching: {query}
- [x] search_results_received → {resultCount} results
- [x] waiting_for_task with/without matching tool call
- [x] Multiple progress messages → last one wins
- [x] Result takes priority over progress in format_element
- [x] Full flow: tool_use → progress → result → shows result
- [x] 18 new tests, 257 total tests passing

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)