### PR TITLE
Issue #24: Readme + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,224 @@
+# CLAUDE.md - Claude Code Context for Claude Session Player
+
+## Project Overview
+
+Claude Session Player is a Python tool that replays Claude Code JSONL session files as readable markdown output. It processes session history line-by-line through a stateful render function, converting the raw protocol data into human-readable terminal-style output.
+
+## Quick Commands
+
+```bash
+# Run all tests
+pytest
+
+# Run tests with verbose output
+pytest -xvs
+
+# Run with coverage report
+pytest --cov=claude_session_player --cov-report=term-missing
+
+# Replay a session file
+claude-session-player examples/projects/orca/sessions/014d9d94-xxx.jsonl
+
+# Or via Python module
+python -m claude_session_player.cli path/to/session.jsonl
+```
+
+## Architecture
+
+### Core Flow
+
+```
+JSONL line → classify_line() → render(state, line) → state.to_markdown()
+```
+
+1. **Parser** (`parser.py`): Reads JSONL, classifies lines into 15 `LineType` variants
+2. **Renderer** (`renderer.py`): Dispatches to type-specific handlers, mutates `ScreenState`
+3. **Formatter** (`formatter.py`): Converts `ScreenState` to markdown string
+4. **Models** (`models.py`): `ScreenState` and 6 `ScreenElement` dataclasses
+
+### Key Data Structures
+
+```python
+# Screen state holds all rendered elements
+ScreenState:
+    elements: list[ScreenElement]     # Ordered visual elements
+    tool_calls: dict[str, int]        # tool_use_id → index for result matching
+    current_request_id: str | None    # Groups consecutive assistant blocks
+
+# Element types
+UserMessage(text)                     # ❯ user input
+AssistantText(text, request_id)       # ● response text
+ToolCall(tool_name, tool_use_id, label, result, is_error, progress_text, request_id)
+ThinkingIndicator(request_id)         # ✱ Thinking…
+TurnDuration(duration_ms)             # ✱ Crunched for Xm Ys
+SystemOutput(text)                    # Plain output
+```
+
+### Line Type Classification
+
+```python
+# User messages
+USER_INPUT, TOOL_RESULT, LOCAL_COMMAND_OUTPUT
+
+# Assistant messages
+ASSISTANT_TEXT, TOOL_USE, THINKING
+
+# System messages
+TURN_DURATION, COMPACT_BOUNDARY
+
+# Progress messages (update existing tool calls)
+BASH_PROGRESS, HOOK_PROGRESS, AGENT_PROGRESS,
+QUERY_UPDATE, SEARCH_RESULTS, WAITING_FOR_TASK
+
+# Skip
+INVISIBLE
+```
+
+## Coding Conventions
+
+### Python Version
+
+- Target Python 3.12+
+- Use `from __future__ import annotations` for forward references
+- Use `X | None` union syntax (not `Optional[X]`)
+- Use dataclasses, not attrs or pydantic
+
+### Style Guidelines
+
+- No runtime dependencies (stdlib only)
+- Simple if/elif chains (no match/case for 3.9 compat during testing)
+- Table-driven dispatch preferred over long conditionals
+- Defensive handling: unknown types → INVISIBLE, missing fields → empty/None
+
+### Testing
+
+- Tests in `tests/` directory
+- Fixtures in `tests/conftest.py`
+- Snapshot tests in `tests/snapshots/`
+- All tests use pytest
+- Target: comprehensive coverage (currently 99%)
+
+## Important Patterns
+
+### Tool Result Matching
+
+Tool results match to tool calls via `tool_use_id`:
+
+```python
+# When tool_use is rendered:
+state.tool_calls[tool_use_id] = len(state.elements) - 1
+
+# When tool_result arrives:
+if tool_use_id in state.tool_calls:
+    index = state.tool_calls[tool_use_id]
+    element = state.elements[index]
+    element.result = truncate_result(content)
+```
+
+### Request ID Grouping
+
+Consecutive assistant blocks with the same `requestId` render without blank lines between them:
+
+```python
+# In to_markdown():
+if prev_request_id == current_request_id and current_request_id is not None:
+    # No blank line
+else:
+    parts.append("")  # Blank line separator
+```
+
+### Context Compaction
+
+When `compact_boundary` is encountered, clear all state:
+
+```python
+def _render_compact_boundary(state: ScreenState) -> None:
+    state.clear()  # Removes all elements, tool_calls, resets request_id
+```
+
+### Sidechain Messages
+
+Sub-agent messages have `isSidechain=True` and are classified as `INVISIBLE`:
+
+```python
+if line.get("isSidechain") and msg_type in ("user", "assistant"):
+    return LineType.INVISIBLE
+```
+
+## File Locations
+
+### Source Code
+- `claude_session_player/models.py` - Data models
+- `claude_session_player/parser.py` - JSONL parsing, line classification
+- `claude_session_player/renderer.py` - Main render logic
+- `claude_session_player/formatter.py` - Markdown output formatting
+- `claude_session_player/tools.py` - Tool input abbreviation rules
+- `claude_session_player/cli.py` - CLI entry point
+
+### Tests
+- `tests/test_models.py` - Model tests
+- `tests/test_parser.py` - Parser tests
+- `tests/test_renderer.py` - Renderer tests
+- `tests/test_formatter.py` - Formatter tests
+- `tests/test_tools.py` - Tool abbreviation tests
+- `tests/test_integration.py` - Full session replay tests
+- `tests/test_stress.py` - Stress tests with large sessions
+
+### Example Data
+- `examples/projects/*/sessions/*.jsonl` - Real session files
+- `examples/projects/*/sessions/subagents/*.jsonl` - Sub-agent sessions
+- `tests/snapshots/*.md` - Expected output snapshots
+
+### Documentation
+- `README.md` - User documentation
+- `CLAUDE.md` - This file (Claude Code context)
+- `.claude/specs/claude-session-player.md` - Original spec
+- `claude-code-session-protocol-schema.md` - Protocol reference
+- `issues/worklogs/*.md` - Development history
+
+## Common Tasks
+
+### Adding a New Message Type
+
+1. Add variant to `LineType` enum in `parser.py`
+2. Add classification logic in `classify_line()` or helper functions
+3. Add handler in `renderer.py` following the `_render_*` pattern
+4. Add formatting in `formatter.py` if needed
+5. Add tests in appropriate test files
+
+### Adding a New Tool
+
+Add entry to `_TOOL_RULES` in `tools.py`:
+
+```python
+_TOOL_RULES = {
+    # ...
+    "NewTool": ("field_name", None, "truncate"),  # or "basename"
+}
+```
+
+### Debugging Session Replay
+
+```python
+from claude_session_player.parser import read_session, classify_line, LineType
+
+for i, line in enumerate(read_session("session.jsonl")):
+    lt = classify_line(line)
+    if lt != LineType.INVISIBLE:
+        print(f"{i}: {lt.name} - {line.get('type')}")
+```
+
+## Known Limitations
+
+1. **Subagent files produce empty output**: By design, `isSidechain=True` messages are invisible
+2. **No streaming/animated output**: Output is static markdown
+3. **No ANSI colors**: Plain text output only
+4. **Orphan results**: Tool results from before compaction render as SystemOutput
+
+## Protocol Notes
+
+- Session protocol version: v2.0.76 – v2.1.29
+- `parentToolUseID` is at top level of progress messages, not in `data`
+- `toolUseResult` for Task tools is at top level, contains collapsed result
+- Content can be string, list of blocks, or null
+- List content may include non-text blocks (filter for `type: "text"`)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,547 @@
+# Claude Session Player
+
+A Python tool that replays Claude Code JSONL session history files as readable ASCII terminal output in markdown format.
+
+## What It Does
+
+Claude Code stores conversation history in JSONL (JSON Lines) files. Each line represents a "frame update" — a user message, assistant response, tool invocation, or progress update. Claude Session Player processes these session files and renders them as human-readable markdown, showing:
+
+- User prompts (❯)
+- Assistant responses (●)
+- Thinking indicators (✱)
+- Tool calls with their inputs and results
+- Progress updates for long-running commands
+- Turn duration timing
+
+## Installation
+
+### From Source
+
+```bash
+# Clone the repository
+git clone https://github.com/your-org/claude-session-player.git
+cd claude-session-player
+
+# Install in development mode
+pip install -e .
+
+# Or install with dev dependencies for testing
+pip install -e ".[dev]"
+```
+
+### Requirements
+
+- Python 3.12+
+- No runtime dependencies (stdlib only)
+- Dev dependencies: pytest, pytest-cov
+
+## Quick Start
+
+### Command Line
+
+```bash
+# Replay a session file
+claude-session-player path/to/session.jsonl
+
+# Or run as a Python module
+python -m claude_session_player.cli path/to/session.jsonl
+```
+
+### As a Library
+
+```python
+from claude_session_player.models import ScreenState
+from claude_session_player.parser import read_session
+from claude_session_player.renderer import render
+
+# Load and replay a session
+lines = read_session("path/to/session.jsonl")
+state = ScreenState()
+
+for line in lines:
+    render(state, line)
+
+# Get the markdown output
+markdown = state.to_markdown()
+print(markdown)
+```
+
+## Finding Your Session Files
+
+Claude Code stores session files in:
+
+- **macOS**: `~/.claude/projects/<project-hash>/sessions/*.jsonl`
+- **Linux**: `~/.claude/projects/<project-hash>/sessions/*.jsonl`
+- **Windows**: `%USERPROFILE%\.claude\projects\<project-hash>\sessions\*.jsonl`
+
+Each project has a unique hash based on its path. Sessions are named with UUIDs like `a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl`.
+
+## Output Format
+
+### User Messages
+
+User input is prefixed with `❯`:
+
+```
+❯ Hello, can you help me with this code?
+```
+
+Multi-line input:
+
+```
+❯ Here's my code:
+  def foo():
+      return 42
+```
+
+### Assistant Responses
+
+Assistant text is prefixed with `●`:
+
+```
+● I'd be happy to help! Let me take a look at your code.
+```
+
+Multi-line responses maintain the indent:
+
+```
+● Here's how it works:
+  1. First, we initialize the state
+  2. Then we process each line
+  3. Finally, we render the output
+```
+
+### Thinking Indicators
+
+When Claude is thinking (extended thinking mode), a thinking indicator appears:
+
+```
+✱ Thinking…
+```
+
+The raw thinking content is not displayed — just the indicator.
+
+### Tool Calls
+
+Tool invocations show the tool name and abbreviated input:
+
+```
+● Read(config.py)
+● Bash(Run the test suite)
+● Grep(TODO)
+● Task(Explore codebase structure)
+```
+
+Tool inputs are abbreviated to 60 characters. Different tools show different fields:
+
+| Tool | Display Field | Example |
+|------|--------------|---------|
+| Bash | `description` or `command` | `Bash(Install dependencies)` |
+| Read/Write/Edit | `file_path` (basename) | `Read(config.py)` |
+| Glob/Grep | `pattern` | `Glob(**/*.ts)` |
+| Task | `description` | `Task(Research the API…)` |
+| WebSearch | `query` | `WebSearch(Python asyncio tutorial)` |
+| WebFetch | `url` | `WebFetch(https://docs.python.org…)` |
+
+### Tool Results
+
+Successful results appear with `└`:
+
+```
+● Bash(git status)
+  └ On branch main
+    Your branch is up to date with 'origin/main'.
+```
+
+Errors appear with `✗`:
+
+```
+● Read(nonexistent.py)
+  ✗ Error: File not found
+```
+
+Long outputs are truncated to 5 lines:
+
+```
+● Bash(find . -name "*.py")
+  └ ./src/main.py
+    ./src/utils.py
+    ./src/models.py
+    ./tests/test_main.py
+    …
+```
+
+### Progress Updates
+
+Long-running commands show progress updates:
+
+```
+● Bash(npm install)
+  └ added 1432 packages in 45s
+```
+
+Task agent progress:
+
+```
+● Task(Analyze codebase)
+  └ Agent: working…
+```
+
+Web search progress:
+
+```
+● WebSearch(Python best practices 2024)
+  └ Searching: Python best practices 2024
+```
+
+### Turn Duration
+
+After each assistant turn, the processing time is shown:
+
+```
+✱ Crunched for 1m 28s
+```
+
+Or for shorter turns:
+
+```
+✱ Crunched for 5s
+```
+
+## Complete Example
+
+Here's a complete example showing various message types:
+
+```
+❯ Can you help me clean up my project directory?
+
+✱ Thinking…
+● I'll help you clean up the project. Let me remove common build artifacts
+  and cache directories.
+● Bash(Remove node_modules and build artifacts)
+  └ Removed node_modules/
+    Removed dist/
+    Removed .cache/
+● Bash(Remove Python cache files)
+  └ Removed __pycache__/
+    Removed .pytest_cache/
+
+✱ Thinking…
+● Done! I've cleaned up:
+  - `node_modules/`, `dist/`, `.cache/` from the frontend
+  - `__pycache__/`, `.pytest_cache/` from Python
+
+  Your directory is now ready to package.
+
+✱ Crunched for 12s
+```
+
+## API Reference
+
+### Core Functions
+
+#### `render(state: ScreenState, line: dict) -> ScreenState`
+
+Process a single JSONL line and update the screen state.
+
+```python
+from claude_session_player.models import ScreenState
+from claude_session_player.renderer import render
+
+state = ScreenState()
+line = {"type": "user", "message": {"content": "Hello"}}
+state = render(state, line)
+```
+
+**Arguments:**
+- `state`: The current `ScreenState` (mutated in place)
+- `line`: A parsed JSONL line dictionary
+
+**Returns:** The same `state` object, updated.
+
+#### `read_session(path: str) -> list[dict]`
+
+Read and parse all lines from a JSONL session file.
+
+```python
+from claude_session_player.parser import read_session
+
+lines = read_session("session.jsonl")
+for line in lines:
+    print(line.get("type"))
+```
+
+#### `classify_line(line: dict) -> LineType`
+
+Classify a JSONL line into one of 15 line types.
+
+```python
+from claude_session_player.parser import classify_line, LineType
+
+line_type = classify_line({"type": "user", "message": {"content": "hi"}})
+assert line_type == LineType.USER_INPUT
+```
+
+### Data Models
+
+#### `ScreenState`
+
+Mutable state representing the terminal screen.
+
+```python
+from claude_session_player.models import ScreenState
+
+state = ScreenState()
+state.elements      # list[ScreenElement] - rendered elements
+state.tool_calls    # dict[str, int] - tool_use_id → element index
+state.current_request_id  # str | None - current response group
+
+# Get markdown output
+markdown = state.to_markdown()
+
+# Clear all state (used on compaction)
+state.clear()
+```
+
+#### Screen Elements
+
+All visual elements that can appear in the output:
+
+```python
+from claude_session_player.models import (
+    UserMessage,      # User input (❯)
+    AssistantText,    # Assistant response (●)
+    ToolCall,         # Tool invocation (● ToolName(...))
+    ThinkingIndicator,  # Thinking (✱ Thinking…)
+    TurnDuration,     # Timing (✱ Crunched for...)
+    SystemOutput,     # System/local command output
+)
+```
+
+#### LineType Enum
+
+Classification of JSONL line types:
+
+```python
+from claude_session_player.parser import LineType
+
+# User message types
+LineType.USER_INPUT           # Direct user text
+LineType.TOOL_RESULT          # Tool result content
+LineType.LOCAL_COMMAND_OUTPUT # <local-command-stdout>
+
+# Assistant message types
+LineType.ASSISTANT_TEXT       # Text response
+LineType.TOOL_USE            # Tool invocation
+LineType.THINKING            # Thinking block
+
+# System message types
+LineType.TURN_DURATION       # Turn timing
+LineType.COMPACT_BOUNDARY    # Context compaction marker
+
+# Progress message types
+LineType.BASH_PROGRESS       # Bash command output
+LineType.HOOK_PROGRESS       # Hook execution
+LineType.AGENT_PROGRESS      # Sub-agent progress
+LineType.QUERY_UPDATE        # Search query
+LineType.SEARCH_RESULTS      # Search results count
+LineType.WAITING_FOR_TASK    # Waiting for task
+
+# Skip type
+LineType.INVISIBLE           # Metadata, should not render
+```
+
+## Advanced Usage
+
+### Processing Large Sessions
+
+For very large sessions, process incrementally:
+
+```python
+import json
+from claude_session_player.models import ScreenState
+from claude_session_player.renderer import render
+
+state = ScreenState()
+with open("large_session.jsonl") as f:
+    for line_text in f:
+        if line_text.strip():
+            line = json.loads(line_text)
+            render(state, line)
+
+print(state.to_markdown())
+```
+
+### Handling Context Compaction
+
+Claude Code uses "context compaction" to manage long conversations. When a `compact_boundary` is encountered, all prior content is cleared from the state:
+
+```python
+# After compaction, only post-compaction content is visible
+state = ScreenState()
+render(state, user_message_1)    # Will be cleared
+render(state, assistant_reply_1) # Will be cleared
+render(state, compact_boundary)  # Clears all state
+render(state, user_message_2)    # Visible in output
+render(state, assistant_reply_2) # Visible in output
+```
+
+### Sub-Agent Sessions
+
+Task tool invocations spawn sub-agents. Their internal messages have `isSidechain=True` and are rendered as `INVISIBLE`. The Task result shows a collapsed summary:
+
+```
+● Task(Analyze authentication system)
+  └ The codebase uses JWT tokens stored in httpOnly cookies...
+```
+
+Sub-agent session files (in `subagents/` directories) can be replayed but produce empty output since all their messages are sidechain messages.
+
+### Custom Rendering
+
+You can inspect individual elements before final rendering:
+
+```python
+from claude_session_player.models import ScreenState, ToolCall
+from claude_session_player.parser import read_session
+from claude_session_player.renderer import render
+
+state = ScreenState()
+for line in read_session("session.jsonl"):
+    render(state, line)
+
+# Find all tool calls
+tool_calls = [e for e in state.elements if isinstance(e, ToolCall)]
+for tc in tool_calls:
+    print(f"{tc.tool_name}: {tc.label}")
+    if tc.result:
+        print(f"  Result: {tc.result[:50]}...")
+    if tc.is_error:
+        print("  (ERROR)")
+```
+
+### Tool Input Abbreviation
+
+Customize how tool inputs are displayed:
+
+```python
+from claude_session_player.tools import abbreviate_tool_input
+
+# Bash shows description or command
+label = abbreviate_tool_input("Bash", {"description": "Install deps", "command": "npm i"})
+# Returns: "Install deps"
+
+# Read shows basename
+label = abbreviate_tool_input("Read", {"file_path": "/path/to/config.py"})
+# Returns: "config.py"
+
+# Unknown tools return ellipsis
+label = abbreviate_tool_input("CustomTool", {})
+# Returns: "…"
+```
+
+## Message Type Reference
+
+### Visible Message Types
+
+| Type | Subtype | Rendering |
+|------|---------|-----------|
+| `user` | direct input | `❯` prompt prefix |
+| `user` | tool result | Updates tool call with `└` result |
+| `user` | local command | Plain text output |
+| `assistant` | text block | `●` prefix, markdown passthrough |
+| `assistant` | tool_use | `● ToolName(input…)` |
+| `assistant` | thinking | `✱ Thinking…` |
+| `system` | turn_duration | `✱ Crunched for Xm Ys` |
+| `progress` | bash_progress | Updates tool `└` line |
+| `progress` | hook_progress | `└ Hook: {name}` |
+| `progress` | agent_progress | `└ Agent: working…` |
+| `progress` | query_update | `└ Searching: {query}` |
+| `progress` | search_results | `└ {count} results` |
+| `progress` | waiting_for_task | `└ Waiting: {description}` |
+
+### Invisible Message Types
+
+These message types are intentionally not rendered:
+
+- `user` with `isMeta=true` (skill expansions)
+- `user` with `isSidechain=true` (sub-agent messages)
+- `assistant` with `isSidechain=true` (sub-agent messages)
+- `system` with `subtype="local_command"`
+- `system` with `subtype="compact_boundary"` (triggers state clear)
+- `summary` (context summary after compaction)
+- `file-history-snapshot`
+- `queue-operation`
+- `pr-link`
+
+## Development
+
+### Running Tests
+
+```bash
+# Run all tests
+pytest
+
+# Run with verbose output
+pytest -xvs
+
+# Run with coverage
+pytest --cov=claude_session_player --cov-report=term-missing
+
+# Run specific test file
+pytest tests/test_renderer.py
+```
+
+### Test Structure
+
+```
+tests/
+├── test_models.py      # Data model tests
+├── test_parser.py      # JSONL parsing tests
+├── test_formatter.py   # Markdown formatting tests
+├── test_renderer.py    # Render function tests
+├── test_tools.py       # Tool abbreviation tests
+├── test_integration.py # Full session replay tests
+├── test_stress.py      # Large session stress tests
+├── conftest.py         # Shared fixtures
+└── snapshots/          # Expected output snapshots
+```
+
+### Project Structure
+
+```
+claude_session_player/
+├── __init__.py       # Package init, version
+├── models.py         # ScreenState, ScreenElement dataclasses
+├── renderer.py       # render() function, dispatch logic
+├── formatter.py      # to_markdown() and formatting helpers
+├── parser.py         # JSONL reading, line classification
+├── tools.py          # Tool-specific abbreviation rules
+└── cli.py            # CLI entry point
+```
+
+## Troubleshooting
+
+### Empty Output
+
+If you get empty output, check if:
+
+1. The session file exists and contains valid JSONL
+2. All messages might be `isSidechain=true` (sub-agent file)
+3. A `compact_boundary` near the end cleared all content
+
+### Orphan Tool Results
+
+If you see tool results rendered as plain text (not attached to tool calls), the session likely had context compaction that cleared the original tool call.
+
+### Unicode Issues
+
+The tool uses Unicode symbols (`❯`, `●`, `✱`, `└`, `✗`, `…`). Ensure your terminal supports UTF-8 encoding.
+
+## Protocol Reference
+
+Claude Session Player implements the Claude Code Session Protocol (v2.0.76 – v2.1.29). See `claude-code-session-protocol-schema.md` for the complete protocol specification.
+
+## License
+
+MIT License - see LICENSE file for details.

--- a/issues/worklogs/24-worklog.md
+++ b/issues/worklogs/24-worklog.md
@@ -1,0 +1,71 @@
+# Issue 24 Worklog: README + CLAUDE.md
+
+## Summary
+
+Created comprehensive documentation for the Claude Session Player project, including a detailed README.md with usage examples and a CLAUDE.md file for Claude Code context.
+
+## Files Created
+
+| File | Description |
+|------|-------------|
+| `README.md` | Comprehensive user documentation with installation, usage examples, API reference |
+| `CLAUDE.md` | Claude Code context file with architecture overview, coding conventions, common tasks |
+
+## README.md Contents
+
+The README includes:
+
+1. **What It Does**: Overview of the tool's purpose
+2. **Installation**: From source with pip
+3. **Quick Start**: CLI and library usage examples
+4. **Finding Session Files**: Locations for macOS, Linux, Windows
+5. **Output Format**: Detailed explanation of all visual elements:
+   - User messages (❯)
+   - Assistant responses (●)
+   - Thinking indicators (✱)
+   - Tool calls with abbreviations
+   - Tool results (└ for success, ✗ for errors)
+   - Progress updates
+   - Turn duration
+6. **Complete Example**: Full conversation showing multiple message types
+7. **API Reference**: Documentation for core functions and data models
+8. **Advanced Usage**: Large sessions, context compaction, sub-agents, custom rendering
+9. **Message Type Reference**: Tables of visible and invisible message types
+10. **Development**: Testing and project structure
+11. **Troubleshooting**: Common issues and solutions
+
+## CLAUDE.md Contents
+
+The CLAUDE.md includes:
+
+1. **Project Overview**: Quick description
+2. **Quick Commands**: Common pytest and CLI commands
+3. **Architecture**: Core flow diagram and key data structures
+4. **Line Type Classification**: All 15 line types
+5. **Coding Conventions**: Python version, style guidelines, testing
+6. **Important Patterns**: Tool result matching, request ID grouping, compaction, sidechain
+7. **File Locations**: Source, tests, examples, documentation
+8. **Common Tasks**: Adding new message types, tools, debugging
+9. **Known Limitations**: Documented constraints
+10. **Protocol Notes**: Key protocol details discovered during implementation
+
+## Decisions Made
+
+- **Comprehensive examples**: Included extensive code examples showing both CLI and library usage
+- **Visual reference**: Documented all Unicode symbols used (❯, ●, ✱, └, ✗, …)
+- **Tool abbreviation table**: Created reference table showing which field each tool displays
+- **API documentation**: Documented all public functions and data classes
+- **Troubleshooting section**: Added common issues users might encounter
+- **CLAUDE.md format**: Followed standard CLAUDE.md structure for Claude Code projects
+
+## Test Results
+
+```
+341 passed
+```
+
+No tests were added or modified — this issue only adds documentation files.
+
+## Deviations from Spec
+
+None. The issue requested "extensive readme + claude.md files" with "a lot of examples and explanations," which was delivered.


### PR DESCRIPTION
## Summary

- Add comprehensive README.md with installation guide, usage examples, API reference, and troubleshooting
- Add CLAUDE.md for Claude Code context with architecture overview, coding conventions, and common tasks
- Create worklog documenting the implementation

## Test plan

- [x] All 341 existing tests pass
- [x] README examples are accurate and reflect actual API
- [x] CLAUDE.md commands work (`pytest`, `claude-session-player`)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)