### PR TITLE
Issue #28: ScreenStateConsumer for event-driven renderer

### DIFF
--- a/claude_session_player/consumer.py
+++ b/claude_session_player/consumer.py
@@ -1,0 +1,188 @@
+"""Event consumer: builds full conversation state from events."""
+
+from __future__ import annotations
+
+from .events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    ClearAll,
+    DurationContent,
+    Event,
+    ProcessingContext,
+    SystemContent,
+    ThinkingContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from .formatter import format_duration
+
+
+class ScreenStateConsumer:
+    """Builds full conversation state from events.
+
+    This consumer accumulates blocks from events, providing backwards
+    compatibility with the existing CLI and replay-session.sh.
+    """
+
+    def __init__(self) -> None:
+        self.blocks: list[Block] = []
+        self._block_index: dict[str, int] = {}  # block_id → index in blocks
+
+    def handle(self, event: Event) -> None:
+        """Process a single event.
+
+        Args:
+            event: An AddBlock, UpdateBlock, or ClearAll event.
+        """
+        if isinstance(event, AddBlock):
+            self._block_index[event.block.id] = len(self.blocks)
+            self.blocks.append(event.block)
+        elif isinstance(event, UpdateBlock):
+            index = self._block_index[event.block_id]
+            # Create new Block with updated content (immutable update)
+            old_block = self.blocks[index]
+            self.blocks[index] = Block(
+                id=old_block.id,
+                type=old_block.type,
+                content=event.content,
+                request_id=old_block.request_id,
+            )
+        elif isinstance(event, ClearAll):
+            self.blocks.clear()
+            self._block_index.clear()
+
+    def to_markdown(self) -> str:
+        """Render all blocks as markdown.
+
+        Blocks sharing the same non-None request_id are grouped together
+        with no blank line between them. Different groups are separated
+        by a blank line.
+
+        Returns:
+            Markdown string representation of all blocks.
+        """
+        parts: list[str] = []
+        prev_request_id: str | None = None
+
+        for block in self.blocks:
+            formatted = format_block(block)
+            if not formatted:
+                continue
+
+            current_rid = block.request_id
+
+            # Insert blank line separator unless both previous and current
+            # share the same non-None request_id
+            if parts and not (
+                prev_request_id and current_rid and prev_request_id == current_rid
+            ):
+                parts.append("")  # blank line
+
+            parts.append(formatted)
+            prev_request_id = current_rid
+
+        return "\n".join(parts)
+
+
+def format_block(block: Block) -> str:
+    """Format a single block as markdown.
+
+    Args:
+        block: The block to format.
+
+    Returns:
+        Markdown string representation of the block.
+    """
+    content = block.content
+
+    if isinstance(content, UserContent):
+        return format_user_text(content.text)
+    elif isinstance(content, AssistantContent):
+        return format_assistant_text(content.text)
+    elif isinstance(content, ToolCallContent):
+        return format_tool_call(content)
+    elif isinstance(content, ThinkingContent):
+        return "\u2731 Thinking\u2026"
+    elif isinstance(content, DurationContent):
+        return f"\u2731 Crunched for {format_duration(content.duration_ms)}"
+    elif isinstance(content, SystemContent):
+        return content.text
+
+    return ""
+
+
+def format_user_text(text: str) -> str:
+    """Format user input text with ❯ prompt prefix.
+
+    First line gets ``❯ `` prefix, subsequent lines are indented 2 spaces.
+    """
+    lines = text.split("\n")
+    if not lines or (len(lines) == 1 and lines[0] == ""):
+        return "❯"
+    result = [f"❯ {lines[0]}"]
+    for line in lines[1:]:
+        result.append(f"  {line}")
+    return "\n".join(result)
+
+
+def format_assistant_text(text: str) -> str:
+    """Format assistant text with ● prefix.
+
+    First line gets ``● `` prefix, continuation lines are indented 2 spaces.
+    Markdown in text is passed through verbatim.
+    """
+    lines = text.split("\n")
+    if not lines or (len(lines) == 1 and lines[0] == ""):
+        return "●"
+    result = [f"● {lines[0]}"]
+    for line in lines[1:]:
+        result.append(f"  {line}")
+    return "\n".join(result)
+
+
+def format_tool_call(content: ToolCallContent) -> str:
+    """Format a tool call block as markdown.
+
+    Args:
+        content: The ToolCallContent to format.
+
+    Returns:
+        Formatted tool call string with optional result/progress.
+    """
+    line = f"\u25cf {content.tool_name}({content.label})"
+
+    # Result takes priority over progress (result is the final state)
+    if content.result is not None:
+        prefix = "  \u2717 " if content.is_error else "  \u2514 "
+        result_lines = content.result.split("\n")
+        line += f"\n{prefix}{result_lines[0]}"
+        # Subsequent lines indented with 4 spaces to align with text after └/✗
+        for result_line in result_lines[1:]:
+            line += f"\n    {result_line}"
+    elif content.progress_text is not None:
+        line += f"\n  \u2514 {content.progress_text}"
+
+    return line
+
+
+def replay_session(lines: list[dict]) -> str:
+    """Convenience function for replaying a full session.
+
+    Args:
+        lines: List of parsed JSONL line dicts.
+
+    Returns:
+        Markdown string of the entire session.
+    """
+    from .processor import process_line
+
+    context = ProcessingContext()
+    consumer = ScreenStateConsumer()
+
+    for line in lines:
+        for event in process_line(context, line):
+            consumer.handle(event)
+
+    return consumer.to_markdown()

--- a/issues/worklogs/28-worklog.md
+++ b/issues/worklogs/28-worklog.md
@@ -1,0 +1,102 @@
+# Issue 28 Worklog: ScreenStateConsumer
+
+## Summary
+
+Implemented `ScreenStateConsumer` class that builds full conversation state from events, providing backwards compatibility with the existing CLI and `replay-session.sh`. This is Phase 3 of the event-driven renderer specification.
+
+## Files Created
+
+| File | Description |
+|------|-------------|
+| `claude_session_player/consumer.py` | ScreenStateConsumer class, format_block(), replay_session() |
+| `tests/test_consumer.py` | 30 unit tests covering all functionality |
+
+## Implementation Details
+
+### ScreenStateConsumer Class
+
+```python
+class ScreenStateConsumer:
+    def __init__(self) -> None:
+        self.blocks: list[Block] = []
+        self._block_index: dict[str, int] = {}  # block_id → index
+
+    def handle(self, event: Event) -> None:
+        """Process AddBlock, UpdateBlock, or ClearAll events."""
+
+    def to_markdown(self) -> str:
+        """Render all blocks with request_id grouping."""
+```
+
+### Event Handling
+
+- `AddBlock`: Appends block to list, stores index in `_block_index`
+- `UpdateBlock`: Creates new Block with updated content (immutable update pattern)
+- `ClearAll`: Clears both `blocks` and `_block_index`
+
+### Formatting Functions
+
+| Function | Description |
+|----------|-------------|
+| `format_block(block)` | Dispatches to type-specific formatters |
+| `format_user_text(text)` | `❯` prefix with 2-space continuation indent |
+| `format_assistant_text(text)` | `●` prefix with 2-space continuation indent |
+| `format_tool_call(content)` | Tool name/label with optional result/progress |
+
+### Convenience Function
+
+```python
+def replay_session(lines: list[dict]) -> str:
+    """Process JSONL lines and return markdown output."""
+```
+
+This provides a simple entry point that matches the old API pattern.
+
+## Test Summary
+
+| Test Class | Test Count | Coverage |
+|------------|------------|----------|
+| `TestAddBlock` | 3 | Appends, updates index, multiple blocks |
+| `TestUpdateBlock` | 3 | Modifies content, preserves metadata |
+| `TestClearAll` | 2 | Empties state, allows new blocks after |
+| `TestToMarkdownUserContent` | 2 | Single-line, multiline |
+| `TestToMarkdownAssistantContent` | 2 | Single-line, multiline |
+| `TestToMarkdownToolCallContent` | 4 | No result, with result, with error, with progress |
+| `TestToMarkdownOtherContent` | 4 | Thinking, duration (2 formats), system |
+| `TestRequestIdGrouping` | 3 | Same ID (no gap), different IDs (gap), None IDs |
+| `TestReplaySession` | 3 | End-to-end, empty, tool calls |
+| `TestFormatHelpers` | 4 | Empty strings, result priority, all content types |
+| **Total** | **30** | All requirements covered |
+
+## Test Results
+
+```
+441 passed in 10.30s
+```
+
+- 411 existing tests: all pass (no regressions)
+- 30 new tests: all pass
+
+## Decisions Made
+
+1. **Immutable update pattern**: For `UpdateBlock`, create a new `Block` instance rather than mutating the existing one. This matches the spec example and keeps blocks more predictable.
+
+2. **Duplicated format functions**: Created separate `format_user_text()` and `format_assistant_text()` in consumer.py rather than importing from formatter.py. This avoids circular dependencies and keeps the consumer module self-contained with all the formatting logic it needs.
+
+3. **Reused format_duration**: Imported `format_duration()` from formatter.py since it's a pure utility function with no dependencies.
+
+4. **Late import for replay_session**: Used a local import for `process_line` inside `replay_session()` to avoid circular import issues.
+
+## Deviations from Spec
+
+1. **Test count**: Spec requested ≥20 tests, implementation has 30 tests for more comprehensive coverage.
+
+2. **Format functions**: Created local format functions rather than updating formatter.py, to keep the new event-driven code separate from the legacy code until Phase 4 (Integration & Migration).
+
+## Definition of Done Checklist
+
+- [x] ScreenStateConsumer handles all event types (AddBlock, UpdateBlock, ClearAll)
+- [x] to_markdown() produces output matching the old formatter's format
+- [x] replay_session() convenience function works
+- [x] ≥20 unit tests (30 tests), all passing
+- [x] All prior tests still pass (441 total)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,0 +1,648 @@
+"""Tests for the ScreenStateConsumer and related formatting functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_session_player.consumer import (
+    ScreenStateConsumer,
+    format_assistant_text,
+    format_block,
+    format_tool_call,
+    format_user_text,
+    replay_session,
+)
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    ProcessingContext,
+    SystemContent,
+    ThinkingContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def consumer() -> ScreenStateConsumer:
+    """Create a fresh ScreenStateConsumer instance."""
+    return ScreenStateConsumer()
+
+
+@pytest.fixture
+def user_block() -> Block:
+    """Create a sample user block."""
+    return Block(
+        id="block-user-1",
+        type=BlockType.USER,
+        content=UserContent(text="Hello, Claude"),
+    )
+
+
+@pytest.fixture
+def assistant_block() -> Block:
+    """Create a sample assistant block."""
+    return Block(
+        id="block-assistant-1",
+        type=BlockType.ASSISTANT,
+        content=AssistantContent(text="Hello! How can I help you?"),
+        request_id="req-123",
+    )
+
+
+@pytest.fixture
+def tool_call_block() -> Block:
+    """Create a sample tool call block."""
+    return Block(
+        id="block-tool-1",
+        type=BlockType.TOOL_CALL,
+        content=ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-use-1",
+            label="README.md",
+        ),
+        request_id="req-123",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test AddBlock event handling
+# ---------------------------------------------------------------------------
+
+
+class TestAddBlock:
+    """Tests for AddBlock event handling."""
+
+    def test_add_block_appends_to_blocks_list(
+        self, consumer: ScreenStateConsumer, user_block: Block
+    ) -> None:
+        """AddBlock appends to blocks list."""
+        consumer.handle(AddBlock(block=user_block))
+        assert len(consumer.blocks) == 1
+        assert consumer.blocks[0] is user_block
+
+    def test_add_block_updates_block_index(
+        self, consumer: ScreenStateConsumer, user_block: Block
+    ) -> None:
+        """AddBlock updates block_index."""
+        consumer.handle(AddBlock(block=user_block))
+        assert consumer._block_index["block-user-1"] == 0
+
+    def test_multiple_add_blocks_in_sequence(
+        self,
+        consumer: ScreenStateConsumer,
+        user_block: Block,
+        assistant_block: Block,
+        tool_call_block: Block,
+    ) -> None:
+        """Multiple AddBlock events in sequence."""
+        consumer.handle(AddBlock(block=user_block))
+        consumer.handle(AddBlock(block=assistant_block))
+        consumer.handle(AddBlock(block=tool_call_block))
+
+        assert len(consumer.blocks) == 3
+        assert consumer.blocks[0] is user_block
+        assert consumer.blocks[1] is assistant_block
+        assert consumer.blocks[2] is tool_call_block
+
+        assert consumer._block_index["block-user-1"] == 0
+        assert consumer._block_index["block-assistant-1"] == 1
+        assert consumer._block_index["block-tool-1"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test UpdateBlock event handling
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBlock:
+    """Tests for UpdateBlock event handling."""
+
+    def test_update_block_modifies_existing_content(
+        self, consumer: ScreenStateConsumer, tool_call_block: Block
+    ) -> None:
+        """UpdateBlock modifies existing block content."""
+        consumer.handle(AddBlock(block=tool_call_block))
+
+        updated_content = ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-use-1",
+            label="README.md",
+            result="# Project Title\n\nSome content here.",
+        )
+        consumer.handle(UpdateBlock(block_id="block-tool-1", content=updated_content))
+
+        assert consumer.blocks[0].content == updated_content
+
+    def test_update_block_preserves_id_type_request_id(
+        self, consumer: ScreenStateConsumer, tool_call_block: Block
+    ) -> None:
+        """UpdateBlock preserves block id, type, request_id."""
+        consumer.handle(AddBlock(block=tool_call_block))
+
+        updated_content = ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-use-1",
+            label="README.md",
+            result="File contents here",
+        )
+        consumer.handle(UpdateBlock(block_id="block-tool-1", content=updated_content))
+
+        updated_block = consumer.blocks[0]
+        assert updated_block.id == "block-tool-1"
+        assert updated_block.type == BlockType.TOOL_CALL
+        assert updated_block.request_id == "req-123"
+
+    def test_update_block_after_add_block_for_same_block(
+        self, consumer: ScreenStateConsumer, tool_call_block: Block
+    ) -> None:
+        """UpdateBlock after AddBlock for same block."""
+        # Add the tool call
+        consumer.handle(AddBlock(block=tool_call_block))
+        assert consumer.blocks[0].content.result is None
+
+        # Update with result
+        updated_content = ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-use-1",
+            label="README.md",
+            result="Success!",
+            is_error=False,
+        )
+        consumer.handle(UpdateBlock(block_id="block-tool-1", content=updated_content))
+
+        # Verify the update
+        assert consumer.blocks[0].content.result == "Success!"
+        assert consumer.blocks[0].content.is_error is False
+
+
+# ---------------------------------------------------------------------------
+# Test ClearAll event handling
+# ---------------------------------------------------------------------------
+
+
+class TestClearAll:
+    """Tests for ClearAll event handling."""
+
+    def test_clear_all_empties_blocks_and_index(
+        self,
+        consumer: ScreenStateConsumer,
+        user_block: Block,
+        assistant_block: Block,
+    ) -> None:
+        """ClearAll empties blocks and index."""
+        consumer.handle(AddBlock(block=user_block))
+        consumer.handle(AddBlock(block=assistant_block))
+
+        assert len(consumer.blocks) == 2
+        assert len(consumer._block_index) == 2
+
+        consumer.handle(ClearAll())
+
+        assert len(consumer.blocks) == 0
+        assert len(consumer._block_index) == 0
+
+    def test_clear_all_followed_by_new_add_block(
+        self, consumer: ScreenStateConsumer, user_block: Block, assistant_block: Block
+    ) -> None:
+        """ClearAll followed by new AddBlock."""
+        consumer.handle(AddBlock(block=user_block))
+        consumer.handle(ClearAll())
+        consumer.handle(AddBlock(block=assistant_block))
+
+        assert len(consumer.blocks) == 1
+        assert consumer.blocks[0] is assistant_block
+        assert consumer._block_index["block-assistant-1"] == 0
+        assert "block-user-1" not in consumer._block_index
+
+
+# ---------------------------------------------------------------------------
+# Test to_markdown() formatting
+# ---------------------------------------------------------------------------
+
+
+class TestToMarkdownUserContent:
+    """Tests for to_markdown() with UserContent."""
+
+    def test_formats_user_content_correctly(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats UserContent correctly."""
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="Hello, Claude"),
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "❯ Hello, Claude"
+
+    def test_formats_multiline_user_content(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats multiline UserContent."""
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="Line 1\nLine 2\nLine 3"),
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "❯ Line 1\n  Line 2\n  Line 3"
+
+
+class TestToMarkdownAssistantContent:
+    """Tests for to_markdown() with AssistantContent."""
+
+    def test_formats_assistant_content_correctly(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats AssistantContent correctly."""
+        block = Block(
+            id="block-1",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="Here is my response."),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● Here is my response."
+
+    def test_formats_multiline_assistant_content(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats multiline AssistantContent."""
+        block = Block(
+            id="block-1",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="First line\nSecond line"),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● First line\n  Second line"
+
+
+class TestToMarkdownToolCallContent:
+    """Tests for to_markdown() with ToolCallContent."""
+
+    def test_formats_tool_call_no_result(self, consumer: ScreenStateConsumer) -> None:
+        """to_markdown() formats ToolCallContent (no result)."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="config.py",
+            ),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● Read(config.py)"
+
+    def test_formats_tool_call_with_result(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats ToolCallContent (with result)."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="List files",
+                result="file1.py\nfile2.py",
+            ),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● Bash(List files)\n  └ file1.py\n    file2.py"
+
+    def test_formats_tool_call_with_error(self, consumer: ScreenStateConsumer) -> None:
+        """to_markdown() formats ToolCallContent (with error)."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="missing.txt",
+                result="File not found",
+                is_error=True,
+            ),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● Read(missing.txt)\n  ✗ File not found"
+
+    def test_formats_tool_call_with_progress(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats ToolCallContent (with progress)."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="Run tests",
+                progress_text="Test 5 of 10...",
+            ),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "● Bash(Run tests)\n  └ Test 5 of 10..."
+
+
+class TestToMarkdownOtherContent:
+    """Tests for to_markdown() with other content types."""
+
+    def test_formats_thinking_content(self, consumer: ScreenStateConsumer) -> None:
+        """to_markdown() formats ThinkingContent."""
+        block = Block(
+            id="block-1",
+            type=BlockType.THINKING,
+            content=ThinkingContent(),
+            request_id="req-1",
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "✱ Thinking…"
+
+    def test_formats_duration_content(self, consumer: ScreenStateConsumer) -> None:
+        """to_markdown() formats DurationContent."""
+        block = Block(
+            id="block-1",
+            type=BlockType.DURATION,
+            content=DurationContent(duration_ms=65000),  # 1m 5s
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "✱ Crunched for 1m 5s"
+
+    def test_formats_duration_content_seconds_only(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() formats DurationContent with seconds only."""
+        block = Block(
+            id="block-1",
+            type=BlockType.DURATION,
+            content=DurationContent(duration_ms=45000),  # 45s
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "✱ Crunched for 45s"
+
+    def test_formats_system_content(self, consumer: ScreenStateConsumer) -> None:
+        """to_markdown() formats SystemContent."""
+        block = Block(
+            id="block-1",
+            type=BlockType.SYSTEM,
+            content=SystemContent(text="Build completed successfully."),
+        )
+        consumer.handle(AddBlock(block=block))
+
+        result = consumer.to_markdown()
+        assert result == "Build completed successfully."
+
+
+# ---------------------------------------------------------------------------
+# Test request_id grouping
+# ---------------------------------------------------------------------------
+
+
+class TestRequestIdGrouping:
+    """Tests for request_id grouping in to_markdown()."""
+
+    def test_groups_by_request_id_no_blank_line(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() groups by request_id (no blank line)."""
+        # Two blocks with the same request_id should have no blank line between them
+        block1 = Block(
+            id="block-1",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="First part"),
+            request_id="req-123",
+        )
+        block2 = Block(
+            id="block-2",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="file.txt",
+            ),
+            request_id="req-123",
+        )
+        consumer.handle(AddBlock(block=block1))
+        consumer.handle(AddBlock(block=block2))
+
+        result = consumer.to_markdown()
+        # No blank line between blocks with same request_id
+        assert result == "● First part\n● Read(file.txt)"
+
+    def test_separates_different_request_ids_blank_line(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() separates different request_ids (blank line)."""
+        block1 = Block(
+            id="block-1",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="Response 1"),
+            request_id="req-1",
+        )
+        block2 = Block(
+            id="block-2",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="Response 2"),
+            request_id="req-2",
+        )
+        consumer.handle(AddBlock(block=block1))
+        consumer.handle(AddBlock(block=block2))
+
+        result = consumer.to_markdown()
+        # Blank line between blocks with different request_ids
+        assert result == "● Response 1\n\n● Response 2"
+
+    def test_separates_none_request_ids_blank_line(
+        self, consumer: ScreenStateConsumer
+    ) -> None:
+        """to_markdown() separates None request_ids (blank line)."""
+        # User message (no request_id) followed by duration (no request_id)
+        block1 = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="Hello"),
+        )
+        block2 = Block(
+            id="block-2",
+            type=BlockType.DURATION,
+            content=DurationContent(duration_ms=5000),
+        )
+        consumer.handle(AddBlock(block=block1))
+        consumer.handle(AddBlock(block=block2))
+
+        result = consumer.to_markdown()
+        # Blank line between blocks with None request_ids
+        assert result == "❯ Hello\n\n✱ Crunched for 5s"
+
+
+# ---------------------------------------------------------------------------
+# Test replay_session() convenience function
+# ---------------------------------------------------------------------------
+
+
+class TestReplaySession:
+    """Tests for replay_session() convenience function."""
+
+    def test_replay_session_works_end_to_end(self) -> None:
+        """replay_session() convenience function works end-to-end."""
+        # Create a minimal session with user input and assistant response
+        lines = [
+            {
+                "type": "user",
+                "message": {"content": "Hello, Claude", "role": "user"},
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "Hello! How can I help?"}],
+                    "role": "assistant",
+                },
+                "requestId": "req-123",
+            },
+        ]
+
+        result = replay_session(lines)
+
+        assert "❯ Hello, Claude" in result
+        assert "● Hello! How can I help?" in result
+
+    def test_replay_session_handles_empty_lines(self) -> None:
+        """replay_session() handles empty session."""
+        result = replay_session([])
+        assert result == ""
+
+    def test_replay_session_handles_tool_calls_and_results(self) -> None:
+        """replay_session() handles tool calls and results."""
+        lines = [
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool-use-abc",
+                            "name": "Read",
+                            "input": {"file_path": "/path/to/file.txt"},
+                        }
+                    ],
+                    "role": "assistant",
+                },
+                "requestId": "req-456",
+            },
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tool-use-abc",
+                            "content": "File contents here",
+                        }
+                    ],
+                    "role": "user",
+                },
+            },
+        ]
+
+        result = replay_session(lines)
+
+        assert "● Read(file.txt)" in result
+        assert "└ File contents here" in result
+
+
+# ---------------------------------------------------------------------------
+# Test format helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHelpers:
+    """Tests for format helper functions."""
+
+    def test_format_user_text_empty(self) -> None:
+        """format_user_text handles empty string."""
+        assert format_user_text("") == "❯"
+
+    def test_format_assistant_text_empty(self) -> None:
+        """format_assistant_text handles empty string."""
+        assert format_assistant_text("") == "●"
+
+    def test_format_tool_call_result_priority_over_progress(self) -> None:
+        """format_tool_call gives result priority over progress."""
+        content = ToolCallContent(
+            tool_name="Bash",
+            tool_use_id="tool-1",
+            label="cmd",
+            result="final output",
+            progress_text="still running...",
+        )
+
+        result = format_tool_call(content)
+        assert "final output" in result
+        assert "still running" not in result
+
+    def test_format_block_with_all_content_types(self) -> None:
+        """format_block handles all content types."""
+        # Test each content type
+        user_block = Block(
+            id="1", type=BlockType.USER, content=UserContent(text="test")
+        )
+        assert format_block(user_block) == "❯ test"
+
+        assistant_block = Block(
+            id="2", type=BlockType.ASSISTANT, content=AssistantContent(text="response")
+        )
+        assert format_block(assistant_block) == "● response"
+
+        thinking_block = Block(
+            id="3", type=BlockType.THINKING, content=ThinkingContent()
+        )
+        assert format_block(thinking_block) == "✱ Thinking…"
+
+        duration_block = Block(
+            id="4", type=BlockType.DURATION, content=DurationContent(duration_ms=30000)
+        )
+        assert format_block(duration_block) == "✱ Crunched for 30s"
+
+        system_block = Block(
+            id="5", type=BlockType.SYSTEM, content=SystemContent(text="output")
+        )
+        assert format_block(system_block) == "output"


### PR DESCRIPTION
## Summary

- Implements Phase 3 of the event-driven renderer specification
- Adds `ScreenStateConsumer` class that builds full conversation state from events
- Provides backwards compatibility with the existing CLI and `replay-session.sh`
- Adds `replay_session()` convenience function for simple session replay

## Changes

- Created `claude_session_player/consumer.py` with:
  - `ScreenStateConsumer` class with `handle()` method for all event types
  - `to_markdown()` method with request_id grouping
  - Block formatting functions (`format_block`, `format_user_text`, etc.)
  - `replay_session()` convenience function
- Created `tests/test_consumer.py` with 30 unit tests
- Created `issues/worklogs/28-worklog.md` with implementation details

## Test plan

- [x] All 30 new tests pass
- [x] All 411 existing tests pass (no regressions)
- [x] Total: 441 tests passing

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)