### PR TITLE
Refactor ScreenStateConsumer to implement async Consumer protocol

### DIFF
--- a/claude_session_player/consumer.py
+++ b/claude_session_player/consumer.py
@@ -25,14 +25,29 @@ class ScreenStateConsumer:
 
     This consumer accumulates blocks from events, providing backwards
     compatibility with the existing CLI and replay-session.sh.
+
+    Implements the Consumer protocol from protocol.py for use with EventEmitter.
     """
 
     def __init__(self) -> None:
         self.blocks: list[Block] = []
         self._block_index: dict[str, int] = {}  # block_id → index in blocks
 
+    async def on_event(self, event: Event) -> None:
+        """Process a single event (async protocol method).
+
+        This method implements the Consumer protocol for use with EventEmitter.
+        Internally delegates to the synchronous handle() method.
+
+        Args:
+            event: An AddBlock, UpdateBlock, or ClearAll event.
+        """
+        self.handle(event)
+
     def handle(self, event: Event) -> None:
-        """Process a single event.
+        """Process a single event (synchronous method).
+
+        This method provides backward compatibility with existing code.
 
         Args:
             event: An AddBlock, UpdateBlock, or ClearAll event.
@@ -53,6 +68,20 @@ class ScreenStateConsumer:
         elif isinstance(event, ClearAll):
             self.blocks.clear()
             self._block_index.clear()
+
+    def render_block(self, block: Block) -> str:
+        """Render a block to its markdown string representation.
+
+        This method implements the Consumer protocol. It delegates to the
+        module-level format_block() function for the actual formatting.
+
+        Args:
+            block: The block to render.
+
+        Returns:
+            Markdown string representation of the block.
+        """
+        return format_block(block)
 
     def to_markdown(self) -> str:
         """Render all blocks as markdown.

--- a/issues/worklogs/39-worklog.md
+++ b/issues/worklogs/39-worklog.md
@@ -1,0 +1,76 @@
+# Issue #39: Refactor ScreenStateConsumer to Async Protocol
+
+## Summary
+
+Refactored `ScreenStateConsumer` to implement the `Consumer` protocol from issue #38, adding async `on_event()` and `render_block()` methods while maintaining full backward compatibility.
+
+## Changes Made
+
+### `/Users/agutnikov/work/claude-session-player/claude_session_player/consumer.py`
+
+1. **Added `async def on_event(event: Event) -> None`**
+   - Implements the `Consumer` protocol for use with `EventEmitter`
+   - Internally delegates to the synchronous `handle()` method
+   - No awaits needed since ScreenStateConsumer is internally synchronous
+
+2. **Added `def render_block(block: Block) -> str`**
+   - Implements the `Consumer` protocol's render method
+   - Delegates to the existing `format_block()` module-level function
+   - Allows consistent interface for all consumers
+
+3. **Updated class docstring**
+   - Documents that the class implements the Consumer protocol
+
+4. **Updated `handle()` docstring**
+   - Clarifies this is the synchronous method for backward compatibility
+
+### `/Users/agutnikov/work/claude-session-player/tests/test_consumer.py`
+
+Added 14 new tests in three test classes:
+
+1. **TestAsyncOnEvent** (4 tests)
+   - `test_on_event_handles_add_block` - AddBlock events work
+   - `test_on_event_handles_update_block` - UpdateBlock events work
+   - `test_on_event_handles_clear_all` - ClearAll events work
+   - `test_on_event_produces_same_result_as_handle` - Identical output
+
+2. **TestRenderBlock** (7 tests)
+   - `test_render_block_returns_same_as_format_block` - Consistency check
+   - `test_render_block_for_user_content` - UserContent rendering
+   - `test_render_block_for_assistant_content` - AssistantContent rendering
+   - `test_render_block_for_tool_call_with_result` - ToolCallContent rendering
+   - `test_render_block_for_thinking_content` - ThinkingContent rendering
+   - `test_render_block_for_duration_content` - DurationContent rendering
+   - `test_render_block_for_system_content` - SystemContent rendering
+
+3. **TestConsumerProtocolCompliance** (3 tests)
+   - `test_consumer_implements_protocol` - isinstance check with Consumer
+   - `test_consumer_can_be_used_with_emitter` - EventEmitter subscription
+   - `test_consumer_works_with_emitter_emit` - Full integration test
+
+## Design Decisions
+
+1. **Delegation pattern**: `on_event()` delegates to `handle()` rather than duplicating logic. This ensures the synchronous and async paths always behave identically.
+
+2. **render_block() delegates to format_block()**: Rather than extracting the logic into the method, we delegate to the existing module-level function. This:
+   - Maintains backward compatibility for code using `format_block()` directly
+   - Avoids code duplication
+   - Keeps the implementation simple
+
+3. **Internally synchronous**: Since `ScreenStateConsumer` only modifies in-memory data structures, no actual async operations are needed. The async signature is for protocol compliance.
+
+## Testing
+
+All 343 tests pass:
+- 30 existing consumer tests (unchanged behavior)
+- 14 new async interface tests
+- 299 other tests (unchanged)
+
+## Acceptance Criteria Verification
+
+- [x] `ScreenStateConsumer` implements the `Consumer` protocol from #38
+- [x] `on_event()` handles `AddBlock`, `UpdateBlock`, `ClearAll` as before
+- [x] `render_block()` renders individual blocks to markdown
+- [x] `to_markdown()` still works and produces identical output
+- [x] All existing tests pass
+- [x] New tests for async interface


### PR DESCRIPTION
## Summary
- Refactors `ScreenStateConsumer` to implement the `Consumer` protocol from #38
- Adds `async on_event()` method that delegates to `handle()` for protocol compliance
- Adds `render_block()` method that delegates to `format_block()` for block rendering
- Maintains full backward compatibility with existing `handle()` and `to_markdown()` methods

## Test plan
- [x] All 343 tests pass (14 new tests added)
- [x] Verify `ScreenStateConsumer` is recognized as `Consumer` protocol instance
- [x] Verify `on_event()` produces identical results to `handle()`
- [x] Verify `render_block()` produces identical results to `format_block()`
- [x] Verify integration with `EventEmitter` works correctly

Closes #39

Generated with [Claude Code](https://claude.com/claude-code)