### PR TITLE
Issue #40: Add Slack Consumer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Slack Bot Token for SlackConsumer
+# Get your token from https://api.slack.com/apps
+SLACK_BOT_TOKEN=xoxb-your-token

--- a/claude_session_player/slack_consumer.py
+++ b/claude_session_player/slack_consumer.py
@@ -1,0 +1,443 @@
+"""Slack consumer for posting session events to Slack channels.
+
+This module provides the SlackConsumer class that posts and updates messages
+in a Slack channel or thread as events arrive from the session processor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
+
+from .events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    Event,
+    QuestionContent,
+    SystemContent,
+    ThinkingContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from .formatter import format_duration
+
+logger = logging.getLogger(__name__)
+
+# Slack message character limit
+SLACK_MESSAGE_LIMIT = 4000
+
+
+class SlackConsumer:
+    """Consumer that posts events to Slack.
+
+    This consumer implements the Consumer protocol from protocol.py.
+    It posts new messages for AddBlock events and updates existing messages
+    for UpdateBlock events.
+
+    Attributes:
+        channel: Slack channel ID to post to.
+        thread_ts: Optional thread timestamp to post in a thread.
+    """
+
+    def __init__(
+        self,
+        client: AsyncWebClient,
+        channel: str,
+        thread_ts: str | None = None,
+    ) -> None:
+        """Initialize the Slack consumer.
+
+        Args:
+            client: An initialized AsyncWebClient instance.
+            channel: Slack channel ID to post messages to.
+            thread_ts: Optional thread timestamp to post messages in a thread.
+        """
+        self._client = client
+        self._channel = channel
+        self._thread_ts = thread_ts
+        self._block_to_message_ts: dict[str, str] = {}
+        self._retry_delay = 1.0  # seconds between retries
+
+    @classmethod
+    def from_env(
+        cls,
+        channel: str,
+        thread_ts: str | None = None,
+    ) -> SlackConsumer:
+        """Create a SlackConsumer with token from environment.
+
+        Args:
+            channel: Slack channel ID to post messages to.
+            thread_ts: Optional thread timestamp to post messages in a thread.
+
+        Returns:
+            A configured SlackConsumer instance.
+
+        Raises:
+            ValueError: If SLACK_BOT_TOKEN is not set in environment.
+        """
+        from slack_sdk.web.async_client import AsyncWebClient
+
+        token = os.environ.get("SLACK_BOT_TOKEN")
+        if not token:
+            raise ValueError("SLACK_BOT_TOKEN environment variable is not set")
+
+        client = AsyncWebClient(token=token)
+        return cls(client=client, channel=channel, thread_ts=thread_ts)
+
+    async def on_event(self, event: Event) -> None:
+        """Process a single event.
+
+        AddBlock events post a new message to Slack.
+        UpdateBlock events update an existing message.
+        ClearAll events are ignored.
+
+        Args:
+            event: The event to process (AddBlock, UpdateBlock, or ClearAll).
+        """
+        if isinstance(event, AddBlock):
+            await self._handle_add_block(event)
+        elif isinstance(event, UpdateBlock):
+            await self._handle_update_block(event)
+        elif isinstance(event, ClearAll):
+            # ClearAll is ignored - we don't delete messages from Slack
+            logger.debug(
+                "clear_all_ignored",
+                extra={"reason": "slack_consumer_does_not_delete_messages"},
+            )
+
+    async def _handle_add_block(self, event: AddBlock) -> None:
+        """Handle AddBlock event by posting a new message.
+
+        Args:
+            event: The AddBlock event containing the block to post.
+        """
+        block = event.block
+        text = self.render_block(block)
+
+        if not text:
+            logger.debug(
+                "add_block_skipped",
+                extra={"block_id": block.id, "reason": "empty_render"},
+            )
+            return
+
+        message_ts = await self._post_message_with_retry(text, block.id)
+        if message_ts:
+            self._block_to_message_ts[block.id] = message_ts
+            logger.debug(
+                "block_posted",
+                extra={
+                    "block_id": block.id,
+                    "message_ts": message_ts,
+                    "channel": self._channel,
+                },
+            )
+
+    async def _handle_update_block(self, event: UpdateBlock) -> None:
+        """Handle UpdateBlock event by updating an existing message.
+
+        If the block_id is not found, the update is skipped silently.
+
+        Args:
+            event: The UpdateBlock event containing the update.
+        """
+        block_id = event.block_id
+        message_ts = self._block_to_message_ts.get(block_id)
+
+        if not message_ts:
+            logger.debug(
+                "update_block_skipped",
+                extra={"block_id": block_id, "reason": "unknown_block_id"},
+            )
+            return
+
+        # Create a temporary block to render the updated content
+        # We need to determine the block type from the content
+        block_type = self._content_to_block_type(event.content)
+        temp_block = Block(
+            id=block_id,
+            type=block_type,
+            content=event.content,
+        )
+        text = self.render_block(temp_block)
+
+        if not text:
+            logger.debug(
+                "update_block_skipped",
+                extra={"block_id": block_id, "reason": "empty_render"},
+            )
+            return
+
+        success = await self._update_message_with_retry(text, message_ts, block_id)
+        if success:
+            logger.debug(
+                "block_updated",
+                extra={
+                    "block_id": block_id,
+                    "message_ts": message_ts,
+                    "channel": self._channel,
+                },
+            )
+
+    def _content_to_block_type(self, content) -> BlockType:
+        """Determine block type from content.
+
+        Args:
+            content: The block content.
+
+        Returns:
+            The corresponding BlockType.
+        """
+        if isinstance(content, UserContent):
+            return BlockType.USER
+        elif isinstance(content, AssistantContent):
+            return BlockType.ASSISTANT
+        elif isinstance(content, ToolCallContent):
+            return BlockType.TOOL_CALL
+        elif isinstance(content, QuestionContent):
+            return BlockType.QUESTION
+        elif isinstance(content, ThinkingContent):
+            return BlockType.THINKING
+        elif isinstance(content, DurationContent):
+            return BlockType.DURATION
+        elif isinstance(content, SystemContent):
+            return BlockType.SYSTEM
+        else:
+            return BlockType.SYSTEM
+
+    async def _post_message_with_retry(
+        self, text: str, block_id: str
+    ) -> str | None:
+        """Post a message to Slack with retry logic.
+
+        Retries once on failure, then skips.
+
+        Args:
+            text: The message text to post.
+            block_id: The block ID for logging.
+
+        Returns:
+            The message timestamp if successful, None if failed.
+        """
+        for attempt in range(2):  # Initial attempt + 1 retry
+            try:
+                response = await self._client.chat_postMessage(
+                    channel=self._channel,
+                    text=text,
+                    thread_ts=self._thread_ts,
+                )
+                return response["ts"]
+            except Exception as e:
+                if attempt == 0:
+                    logger.warning(
+                        "post_message_retry",
+                        extra={
+                            "block_id": block_id,
+                            "channel": self._channel,
+                            "error": str(e),
+                            "attempt": attempt + 1,
+                        },
+                    )
+                    await asyncio.sleep(self._retry_delay)
+                else:
+                    logger.error(
+                        "post_message_failed",
+                        extra={
+                            "block_id": block_id,
+                            "channel": self._channel,
+                            "error": str(e),
+                            "attempts": attempt + 1,
+                        },
+                    )
+        return None
+
+    async def _update_message_with_retry(
+        self, text: str, message_ts: str, block_id: str
+    ) -> bool:
+        """Update a Slack message with retry logic.
+
+        Retries once on failure, then skips.
+
+        Args:
+            text: The updated message text.
+            message_ts: The timestamp of the message to update.
+            block_id: The block ID for logging.
+
+        Returns:
+            True if successful, False if failed.
+        """
+        for attempt in range(2):  # Initial attempt + 1 retry
+            try:
+                await self._client.chat_update(
+                    channel=self._channel,
+                    ts=message_ts,
+                    text=text,
+                )
+                return True
+            except Exception as e:
+                if attempt == 0:
+                    logger.warning(
+                        "update_message_retry",
+                        extra={
+                            "block_id": block_id,
+                            "message_ts": message_ts,
+                            "channel": self._channel,
+                            "error": str(e),
+                            "attempt": attempt + 1,
+                        },
+                    )
+                    await asyncio.sleep(self._retry_delay)
+                else:
+                    logger.error(
+                        "update_message_failed",
+                        extra={
+                            "block_id": block_id,
+                            "message_ts": message_ts,
+                            "channel": self._channel,
+                            "error": str(e),
+                            "attempts": attempt + 1,
+                        },
+                    )
+        return False
+
+    def render_block(self, block: Block) -> str:
+        """Render a block to its Slack message representation.
+
+        Respects Slack's 4000 character message limit by truncating if needed.
+
+        Args:
+            block: The block to render.
+
+        Returns:
+            Slack-formatted string representation of the block.
+        """
+        text = self._render_block_content(block)
+        return self._truncate_to_limit(text)
+
+    def _render_block_content(self, block: Block) -> str:
+        """Render block content without truncation.
+
+        Args:
+            block: The block to render.
+
+        Returns:
+            String representation of the block.
+        """
+        content = block.content
+
+        if isinstance(content, UserContent):
+            return self._render_user(content)
+        elif isinstance(content, AssistantContent):
+            return self._render_assistant(content)
+        elif isinstance(content, ToolCallContent):
+            return self._render_tool_call(content)
+        elif isinstance(content, QuestionContent):
+            return self._render_question(content)
+        elif isinstance(content, ThinkingContent):
+            return ":brain: _Thinking..._"
+        elif isinstance(content, DurationContent):
+            return f":stopwatch: Crunched for {format_duration(content.duration_ms)}"
+        elif isinstance(content, SystemContent):
+            return f"```\n{content.text}\n```"
+
+        return ""
+
+    def _render_user(self, content: UserContent) -> str:
+        """Render user content for Slack.
+
+        Args:
+            content: The user content.
+
+        Returns:
+            Formatted user message.
+        """
+        return f":bust_in_silhouette: *User:*\n{content.text}"
+
+    def _render_assistant(self, content: AssistantContent) -> str:
+        """Render assistant content for Slack.
+
+        Args:
+            content: The assistant content.
+
+        Returns:
+            Formatted assistant message.
+        """
+        return f":robot_face: *Claude:*\n{content.text}"
+
+    def _render_tool_call(self, content: ToolCallContent) -> str:
+        """Render tool call content for Slack.
+
+        Args:
+            content: The tool call content.
+
+        Returns:
+            Formatted tool call message.
+        """
+        lines = [f":wrench: `{content.tool_name}({content.label})`"]
+
+        if content.result is not None:
+            prefix = ":x:" if content.is_error else ":white_check_mark:"
+            lines.append(f"{prefix} Result:")
+            lines.append(f"```\n{content.result}\n```")
+        elif content.progress_text is not None:
+            lines.append(f":hourglass: {content.progress_text}")
+
+        return "\n".join(lines)
+
+    def _render_question(self, content: QuestionContent) -> str:
+        """Render question content for Slack.
+
+        Args:
+            content: The question content.
+
+        Returns:
+            Formatted question message.
+        """
+        parts: list[str] = []
+
+        for question in content.questions:
+            header = question.header or "Question"
+            lines = [f":question: *{header}*", question.question]
+
+            answer = None
+            if content.answers:
+                answer = content.answers.get(question.question)
+
+            if answer:
+                lines.append(f":white_check_mark: Selected: _{answer}_")
+            else:
+                for opt in question.options:
+                    lines.append(f"  - {opt.label}")
+                lines.append("_(awaiting response)_")
+
+            parts.append("\n".join(lines))
+
+        return "\n\n".join(parts)
+
+    def _truncate_to_limit(self, text: str) -> str:
+        """Truncate text to Slack's message limit.
+
+        Args:
+            text: The text to truncate.
+
+        Returns:
+            Truncated text with ellipsis if needed.
+        """
+        if len(text) <= SLACK_MESSAGE_LIMIT:
+            return text
+
+        # Leave room for truncation indicator
+        truncation_indicator = "\n... (truncated)"
+        max_length = SLACK_MESSAGE_LIMIT - len(truncation_indicator)
+        return text[:max_length] + truncation_indicator

--- a/issues/worklogs/40-worklog.md
+++ b/issues/worklogs/40-worklog.md
@@ -1,0 +1,95 @@
+# Issue #40: Add Slack Consumer
+
+## Summary
+
+Implemented a Slack consumer that posts and updates messages in a Slack channel or thread as events arrive from the session processor.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/slack_consumer.py`**
+   - `SlackConsumer` class implementing the `Consumer` protocol
+   - Channel ID and optional thread_ts configuration
+   - `_block_to_message_ts` mapping for tracking posted messages
+   - `AddBlock` -> `chat.postMessage`, stores message timestamp
+   - `UpdateBlock` -> `chat.update` using stored timestamp (skips unknown block_id)
+   - `ClearAll` -> ignored (no action)
+   - Retry logic (1 retry, then skip with logging)
+   - `render_block()` for Slack message formatting with 4000 char limit
+   - `from_env()` factory method for creating consumer with `SLACK_BOT_TOKEN` from environment
+
+2. **`tests/test_slack_consumer.py`**
+   - Tests for Consumer protocol compliance
+   - Tests for AddBlock posting messages
+   - Tests for UpdateBlock updating messages
+   - Tests for unknown block_id being skipped
+   - Tests for ClearAll being ignored
+   - Tests for retry logic (retry once, then skip)
+   - Tests for 4000 char limit truncation
+   - Tests for from_env factory method
+   - Tests for multiple events
+   - All tests with mocked Slack API
+   - 32 test cases
+
+3. **`.env.example`**
+   - Template for `SLACK_BOT_TOKEN=xoxb-your-token`
+
+### Modified Files
+
+1. **`pyproject.toml`**
+   - Added `pytest-asyncio` to dev dependencies
+   - Added `slack` optional dependency group with `slack-sdk>=3.0` and `aiohttp>=3.0`
+
+## Technical Details
+
+### SlackConsumer
+
+```python
+class SlackConsumer:
+    def __init__(self, client: AsyncWebClient, channel: str, thread_ts: str | None = None)
+    @classmethod
+    def from_env(cls, channel: str, thread_ts: str | None = None) -> SlackConsumer
+    async def on_event(self, event: Event) -> None
+    def render_block(self, block: Block) -> str
+```
+
+- Uses `slack_sdk.web.async_client.AsyncWebClient` for async Slack API calls
+- Posts messages with `chat.postMessage` and updates with `chat.update`
+- Tracks message timestamps in `_block_to_message_ts` mapping
+- Respects Slack's 4000 character message limit with truncation
+- Retry logic: 1 retry with configurable delay, then skip with logging
+
+### Message Rendering
+
+Each block type is rendered for Slack formatting:
+- User: `:bust_in_silhouette: *User:*` + text
+- Assistant: `:robot_face: *Claude:*` + text
+- Tool call: `:wrench:` + tool name + label, with result/progress
+- Thinking: `:brain: _Thinking..._`
+- Duration: `:stopwatch: Crunched for X`
+- Question: `:question:` with options and answers
+- System: Code block
+
+### Error Handling
+
+- API failures trigger 1 retry with configurable delay (default 1s)
+- After retry fails, operation is skipped with error logging
+- Unknown block_id in UpdateBlock is skipped silently (debug logged)
+- ClearAll is ignored (Slack messages are not deleted)
+
+## Test Coverage
+
+All 375 tests pass:
+- 32 new tests in `test_slack_consumer.py`
+- All existing tests continue to pass
+
+## Acceptance Criteria Status
+
+- [x] `SlackConsumer` implements the `Consumer` protocol
+- [x] Messages posted to configured channel/thread
+- [x] Messages updated when `UpdateBlock` received
+- [x] Retry logic implemented (1 retry, then skip)
+- [x] `.env.example` created with `SLACK_BOT_TOKEN`
+- [x] `slack-sdk` added to dependencies
+- [x] Unit tests with mocked Slack API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ claude-session-player = "claude_session_player.cli:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov", "pytest-asyncio>=0.23"]
+slack = ["slack-sdk>=3.0", "aiohttp>=3.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/test_slack_consumer.py
+++ b/tests/test_slack_consumer.py
@@ -1,0 +1,739 @@
+"""Tests for the SlackConsumer class."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    Event,
+    Question,
+    QuestionContent,
+    QuestionOption,
+    SystemContent,
+    ThinkingContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from claude_session_player.protocol import Consumer
+from claude_session_player.slack_consumer import SLACK_MESSAGE_LIMIT, SlackConsumer
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client() -> AsyncMock:
+    """Create a mock Slack AsyncWebClient."""
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ts": "1234567890.123456"})
+    client.chat_update = AsyncMock(return_value={"ok": True})
+    return client
+
+
+@pytest.fixture
+def consumer(mock_client: AsyncMock) -> SlackConsumer:
+    """Create a SlackConsumer with mocked client."""
+    c = SlackConsumer(
+        client=mock_client,
+        channel="C12345678",
+        thread_ts=None,
+    )
+    # Set retry delay to 0 for faster tests
+    c._retry_delay = 0
+    return c
+
+
+@pytest.fixture
+def consumer_with_thread(mock_client: AsyncMock) -> SlackConsumer:
+    """Create a SlackConsumer with thread_ts."""
+    c = SlackConsumer(
+        client=mock_client,
+        channel="C12345678",
+        thread_ts="1234567890.000000",
+    )
+    c._retry_delay = 0
+    return c
+
+
+@pytest.fixture
+def user_block() -> Block:
+    """Create a sample user block."""
+    return Block(
+        id="block-user-1",
+        type=BlockType.USER,
+        content=UserContent(text="Hello"),
+    )
+
+
+@pytest.fixture
+def assistant_block() -> Block:
+    """Create a sample assistant block."""
+    return Block(
+        id="block-assistant-1",
+        type=BlockType.ASSISTANT,
+        content=AssistantContent(text="Hi there"),
+        request_id="req-123",
+    )
+
+
+@pytest.fixture
+def tool_call_block() -> Block:
+    """Create a sample tool call block."""
+    return Block(
+        id="block-tool-1",
+        type=BlockType.TOOL_CALL,
+        content=ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-1",
+            label="file.txt",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test Consumer protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerProtocol:
+    """Tests for Consumer protocol compliance."""
+
+    def test_slack_consumer_is_consumer(self, consumer: SlackConsumer) -> None:
+        """SlackConsumer implements Consumer protocol."""
+        assert isinstance(consumer, Consumer)
+
+    def test_has_on_event_method(self, consumer: SlackConsumer) -> None:
+        """SlackConsumer has on_event method."""
+        assert hasattr(consumer, "on_event")
+        assert callable(consumer.on_event)
+
+    def test_has_render_block_method(self, consumer: SlackConsumer) -> None:
+        """SlackConsumer has render_block method."""
+        assert hasattr(consumer, "render_block")
+        assert callable(consumer.render_block)
+
+
+# ---------------------------------------------------------------------------
+# Test AddBlock event handling
+# ---------------------------------------------------------------------------
+
+
+class TestAddBlock:
+    """Tests for AddBlock event handling."""
+
+    @pytest.mark.asyncio
+    async def test_add_block_posts_message(
+        self, consumer: SlackConsumer, mock_client: AsyncMock, user_block: Block
+    ) -> None:
+        """AddBlock posts a message to Slack."""
+        event = AddBlock(block=user_block)
+
+        await consumer.on_event(event)
+
+        mock_client.chat_postMessage.assert_called_once()
+        call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["channel"] == "C12345678"
+        assert "Hello" in call_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_add_block_stores_message_ts(
+        self, consumer: SlackConsumer, mock_client: AsyncMock, user_block: Block
+    ) -> None:
+        """AddBlock stores the message timestamp for later updates."""
+        event = AddBlock(block=user_block)
+
+        await consumer.on_event(event)
+
+        assert user_block.id in consumer._block_to_message_ts
+        assert consumer._block_to_message_ts[user_block.id] == "1234567890.123456"
+
+    @pytest.mark.asyncio
+    async def test_add_block_with_thread_ts(
+        self,
+        consumer_with_thread: SlackConsumer,
+        mock_client: AsyncMock,
+        user_block: Block,
+    ) -> None:
+        """AddBlock posts to thread when thread_ts is set."""
+        event = AddBlock(block=user_block)
+
+        await consumer_with_thread.on_event(event)
+
+        call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] == "1234567890.000000"
+
+    @pytest.mark.asyncio
+    async def test_add_block_without_thread_ts(
+        self, consumer: SlackConsumer, mock_client: AsyncMock, user_block: Block
+    ) -> None:
+        """AddBlock posts without thread_ts when not set."""
+        event = AddBlock(block=user_block)
+
+        await consumer.on_event(event)
+
+        call_kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["thread_ts"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test UpdateBlock event handling
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBlock:
+    """Tests for UpdateBlock event handling."""
+
+    @pytest.mark.asyncio
+    async def test_update_block_updates_message(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        tool_call_block: Block,
+    ) -> None:
+        """UpdateBlock updates an existing message."""
+        # First add the block
+        await consumer.on_event(AddBlock(block=tool_call_block))
+
+        # Then update it
+        updated_content = ToolCallContent(
+            tool_name="Read",
+            tool_use_id="tool-1",
+            label="file.txt",
+            result="File contents here",
+        )
+        update_event = UpdateBlock(
+            block_id=tool_call_block.id,
+            content=updated_content,
+        )
+
+        await consumer.on_event(update_event)
+
+        mock_client.chat_update.assert_called_once()
+        call_kwargs = mock_client.chat_update.call_args.kwargs
+        assert call_kwargs["channel"] == "C12345678"
+        assert call_kwargs["ts"] == "1234567890.123456"
+        assert "File contents here" in call_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_update_block_unknown_id_skipped(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """UpdateBlock for unknown block_id is skipped silently."""
+        update_event = UpdateBlock(
+            block_id="unknown-block-id",
+            content=AssistantContent(text="Updated text"),
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await consumer.on_event(update_event)
+
+        mock_client.chat_update.assert_not_called()
+        assert "update_block_skipped" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Test ClearAll event handling
+# ---------------------------------------------------------------------------
+
+
+class TestClearAll:
+    """Tests for ClearAll event handling."""
+
+    @pytest.mark.asyncio
+    async def test_clear_all_ignored(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """ClearAll event is ignored (no action)."""
+        event = ClearAll()
+
+        with caplog.at_level(logging.DEBUG):
+            await consumer.on_event(event)
+
+        # No Slack API calls should be made
+        mock_client.chat_postMessage.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+        assert "clear_all_ignored" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Test retry logic
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLogic:
+    """Tests for retry logic on API failures."""
+
+    @pytest.mark.asyncio
+    async def test_post_message_retries_once(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        user_block: Block,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """post_message retries once on failure."""
+        # First call fails, second succeeds
+        mock_client.chat_postMessage.side_effect = [
+            Exception("Network error"),
+            {"ts": "1234567890.123456"},
+        ]
+        event = AddBlock(block=user_block)
+
+        with caplog.at_level(logging.WARNING):
+            await consumer.on_event(event)
+
+        assert mock_client.chat_postMessage.call_count == 2
+        assert "post_message_retry" in caplog.text
+        assert user_block.id in consumer._block_to_message_ts
+
+    @pytest.mark.asyncio
+    async def test_post_message_fails_after_retry(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        user_block: Block,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """post_message skips after retry fails."""
+        # Both calls fail
+        mock_client.chat_postMessage.side_effect = Exception("Network error")
+        event = AddBlock(block=user_block)
+
+        with caplog.at_level(logging.ERROR):
+            await consumer.on_event(event)
+
+        assert mock_client.chat_postMessage.call_count == 2
+        assert "post_message_failed" in caplog.text
+        assert user_block.id not in consumer._block_to_message_ts
+
+    @pytest.mark.asyncio
+    async def test_update_message_retries_once(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        tool_call_block: Block,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """update_message retries once on failure."""
+        # Add block first
+        await consumer.on_event(AddBlock(block=tool_call_block))
+
+        # First update call fails, second succeeds
+        mock_client.chat_update.side_effect = [
+            Exception("Network error"),
+            {"ok": True},
+        ]
+        update_event = UpdateBlock(
+            block_id=tool_call_block.id,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="file.txt",
+                result="Result",
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await consumer.on_event(update_event)
+
+        assert mock_client.chat_update.call_count == 2
+        assert "update_message_retry" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_update_message_fails_after_retry(
+        self,
+        consumer: SlackConsumer,
+        mock_client: AsyncMock,
+        tool_call_block: Block,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """update_message skips after retry fails."""
+        # Add block first
+        await consumer.on_event(AddBlock(block=tool_call_block))
+
+        # Both update calls fail
+        mock_client.chat_update.side_effect = Exception("Network error")
+        update_event = UpdateBlock(
+            block_id=tool_call_block.id,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="file.txt",
+                result="Result",
+            ),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            await consumer.on_event(update_event)
+
+        assert mock_client.chat_update.call_count == 2
+        assert "update_message_failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Test render_block
+# ---------------------------------------------------------------------------
+
+
+class TestRenderBlock:
+    """Tests for render_block method."""
+
+    def test_render_user_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats user content correctly."""
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="Hello world"),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":bust_in_silhouette:" in result
+        assert "*User:*" in result
+        assert "Hello world" in result
+
+    def test_render_assistant_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats assistant content correctly."""
+        block = Block(
+            id="block-1",
+            type=BlockType.ASSISTANT,
+            content=AssistantContent(text="Hi there!"),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":robot_face:" in result
+        assert "*Claude:*" in result
+        assert "Hi there!" in result
+
+    def test_render_tool_call_without_result(self, consumer: SlackConsumer) -> None:
+        """render_block formats tool call without result."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="ls -la",
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":wrench:" in result
+        assert "`Bash(ls -la)`" in result
+
+    def test_render_tool_call_with_result(self, consumer: SlackConsumer) -> None:
+        """render_block formats tool call with result."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tool-1",
+                label="file.txt",
+                result="File contents",
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":wrench:" in result
+        assert ":white_check_mark:" in result
+        assert "File contents" in result
+
+    def test_render_tool_call_with_error(self, consumer: SlackConsumer) -> None:
+        """render_block formats tool call with error."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="invalid_command",
+                result="Command not found",
+                is_error=True,
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":x:" in result
+        assert "Command not found" in result
+
+    def test_render_tool_call_with_progress(self, consumer: SlackConsumer) -> None:
+        """render_block formats tool call with progress."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="long_command",
+                progress_text="Running...",
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":hourglass:" in result
+        assert "Running..." in result
+
+    def test_render_thinking_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats thinking content."""
+        block = Block(
+            id="block-1",
+            type=BlockType.THINKING,
+            content=ThinkingContent(),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":brain:" in result
+        assert "_Thinking..._" in result
+
+    def test_render_duration_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats duration content."""
+        block = Block(
+            id="block-1",
+            type=BlockType.DURATION,
+            content=DurationContent(duration_ms=65000),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":stopwatch:" in result
+        assert "1m 5s" in result
+
+    def test_render_system_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats system content."""
+        block = Block(
+            id="block-1",
+            type=BlockType.SYSTEM,
+            content=SystemContent(text="System message"),
+        )
+
+        result = consumer.render_block(block)
+
+        assert "```" in result
+        assert "System message" in result
+
+    def test_render_question_content(self, consumer: SlackConsumer) -> None:
+        """render_block formats question content."""
+        block = Block(
+            id="block-1",
+            type=BlockType.QUESTION,
+            content=QuestionContent(
+                tool_use_id="q-1",
+                questions=[
+                    Question(
+                        question="Continue?",
+                        header="Confirm",
+                        options=[
+                            QuestionOption(label="Yes", description="Continue"),
+                            QuestionOption(label="No", description="Cancel"),
+                        ],
+                    )
+                ],
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":question:" in result
+        assert "*Confirm*" in result
+        assert "Continue?" in result
+        assert "- Yes" in result
+        assert "- No" in result
+
+    def test_render_question_with_answer(self, consumer: SlackConsumer) -> None:
+        """render_block formats answered question."""
+        block = Block(
+            id="block-1",
+            type=BlockType.QUESTION,
+            content=QuestionContent(
+                tool_use_id="q-1",
+                questions=[
+                    Question(
+                        question="Continue?",
+                        header="Confirm",
+                        options=[
+                            QuestionOption(label="Yes", description="Continue"),
+                            QuestionOption(label="No", description="Cancel"),
+                        ],
+                    )
+                ],
+                answers={"Continue?": "Yes"},
+            ),
+        )
+
+        result = consumer.render_block(block)
+
+        assert ":white_check_mark:" in result
+        assert "_Yes_" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 4000 character limit
+# ---------------------------------------------------------------------------
+
+
+class TestMessageLimit:
+    """Tests for Slack's 4000 character message limit."""
+
+    def test_truncate_long_message(self, consumer: SlackConsumer) -> None:
+        """render_block truncates messages exceeding 4000 chars."""
+        long_text = "x" * 5000
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text=long_text),
+        )
+
+        result = consumer.render_block(block)
+
+        assert len(result) <= SLACK_MESSAGE_LIMIT
+        assert "... (truncated)" in result
+
+    def test_short_message_not_truncated(self, consumer: SlackConsumer) -> None:
+        """render_block does not truncate short messages."""
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="Short message"),
+        )
+
+        result = consumer.render_block(block)
+
+        assert "... (truncated)" not in result
+
+    def test_exactly_at_limit_not_truncated(self, consumer: SlackConsumer) -> None:
+        """Message exactly at limit is not truncated."""
+        # Create a message that will render to exactly 4000 chars
+        # Account for the formatting prefix
+        prefix = ":bust_in_silhouette: *User:*\n"
+        text_length = SLACK_MESSAGE_LIMIT - len(prefix)
+        block = Block(
+            id="block-1",
+            type=BlockType.USER,
+            content=UserContent(text="x" * text_length),
+        )
+
+        result = consumer.render_block(block)
+
+        assert len(result) == SLACK_MESSAGE_LIMIT
+        assert "... (truncated)" not in result
+
+
+# ---------------------------------------------------------------------------
+# Test from_env factory
+# ---------------------------------------------------------------------------
+
+
+class TestFromEnv:
+    """Tests for from_env factory method."""
+
+    def test_from_env_missing_token(self) -> None:
+        """from_env raises ValueError if token not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="SLACK_BOT_TOKEN"):
+                SlackConsumer.from_env(channel="C12345678")
+
+    def test_from_env_with_token(self) -> None:
+        """from_env creates consumer with token from environment."""
+        with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch(
+                "slack_sdk.web.async_client.AsyncWebClient"
+            ) as mock_client_class:
+                mock_client_class.return_value = MagicMock()
+
+                consumer = SlackConsumer.from_env(
+                    channel="C12345678",
+                    thread_ts="1234567890.000000",
+                )
+
+                mock_client_class.assert_called_once_with(token="xoxb-test-token")
+                assert consumer._channel == "C12345678"
+                assert consumer._thread_ts == "1234567890.000000"
+
+
+# ---------------------------------------------------------------------------
+# Test multiple events
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleEvents:
+    """Tests for handling multiple events."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_add_blocks(
+        self, consumer: SlackConsumer, mock_client: AsyncMock
+    ) -> None:
+        """Multiple AddBlock events post multiple messages."""
+        blocks = [
+            Block(id=f"block-{i}", type=BlockType.USER, content=UserContent(text=f"Message {i}"))
+            for i in range(3)
+        ]
+        # Configure different timestamps for each response
+        mock_client.chat_postMessage.side_effect = [
+            {"ts": f"123456789{i}.000000"} for i in range(3)
+        ]
+
+        for block in blocks:
+            await consumer.on_event(AddBlock(block=block))
+
+        assert mock_client.chat_postMessage.call_count == 3
+        assert len(consumer._block_to_message_ts) == 3
+
+    @pytest.mark.asyncio
+    async def test_add_then_update(
+        self, consumer: SlackConsumer, mock_client: AsyncMock
+    ) -> None:
+        """Add followed by update works correctly."""
+        block = Block(
+            id="block-1",
+            type=BlockType.TOOL_CALL,
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tool-1",
+                label="command",
+            ),
+        )
+
+        # Add the block
+        await consumer.on_event(AddBlock(block=block))
+
+        # Update the block
+        await consumer.on_event(
+            UpdateBlock(
+                block_id="block-1",
+                content=ToolCallContent(
+                    tool_name="Bash",
+                    tool_use_id="tool-1",
+                    label="command",
+                    result="Output",
+                ),
+            )
+        )
+
+        assert mock_client.chat_postMessage.call_count == 1
+        assert mock_client.chat_update.call_count == 1


### PR DESCRIPTION
## Summary

Implements a Slack consumer that posts and updates messages in a Slack channel or thread as events arrive.

## Changes

- `claude_session_player/slack_consumer.py` - SlackConsumer implementing Consumer protocol
- `tests/test_slack_consumer.py` - 32 unit tests with mocked Slack API
- `.env.example` - Template for SLACK_BOT_TOKEN
- `pyproject.toml` - Added slack optional dependency group

## Features

- Posts messages for AddBlock events
- Updates existing messages for UpdateBlock events
- Ignores ClearAll events
- Retry logic (1 retry, then skip)
- Message truncation to 4000 chars
- `from_env()` factory for easy setup

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)