### PR TITLE
Issue #56: Add WatcherService class integrating all components

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -6,6 +6,7 @@ from claude_session_player.watcher.api import WatcherAPI
 from claude_session_player.watcher.config import ConfigManager, SessionConfig
 from claude_session_player.watcher.event_buffer import EventBuffer, EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalReader
+from claude_session_player.watcher.service import WatcherService
 from claude_session_player.watcher.sse import SSEConnection, SSEManager
 from claude_session_player.watcher.state import SessionState, StateManager
 from claude_session_player.watcher.transformer import transform
@@ -22,5 +23,6 @@ __all__ = [
     "SSEManager",
     "StateManager",
     "WatcherAPI",
+    "WatcherService",
     "transform",
 ]

--- a/claude_session_player/watcher/__main__.py
+++ b/claude_session_player/watcher/__main__.py
@@ -1,0 +1,167 @@
+"""CLI entry point for running the watcher service.
+
+Usage:
+    python -m claude_session_player.watcher [options]
+
+Options:
+    --host HOST          Host to bind to (default: 127.0.0.1)
+    --port PORT          Port to bind to (default: 8080)
+    --config PATH        Path to config.yaml (default: ./config.yaml)
+    --state-dir PATH     Path to state directory (default: ./state)
+    --log-level LEVEL    Log level (default: INFO)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import signal
+import sys
+from pathlib import Path
+
+from claude_session_player.watcher.service import WatcherService
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Args:
+        args: Command line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Parsed arguments namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Claude Session Player - Watcher Service",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Start with defaults
+    python -m claude_session_player.watcher
+
+    # Specify config and state directories
+    python -m claude_session_player.watcher --config /etc/watcher/config.yaml --state-dir /var/lib/watcher/state
+
+    # Bind to all interfaces on port 9000
+    python -m claude_session_player.watcher --host 0.0.0.0 --port 9000
+""",
+    )
+
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Host to bind to (default: 127.0.0.1)",
+    )
+
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Port to bind to (default: 8080)",
+    )
+
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to config.yaml (default: ./config.yaml)",
+    )
+
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=Path("state"),
+        help="Path to state directory (default: ./state)",
+    )
+
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Log level (default: INFO)",
+    )
+
+    return parser.parse_args(args)
+
+
+def setup_logging(level: str) -> None:
+    """Configure logging.
+
+    Args:
+        level: Log level name (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+    """
+    logging.basicConfig(
+        level=getattr(logging, level),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+async def run_service(service: WatcherService, shutdown_event: asyncio.Event) -> None:
+    """Run the service until shutdown event is set.
+
+    Args:
+        service: The WatcherService instance.
+        shutdown_event: Event to signal shutdown.
+    """
+    await service.start()
+
+    try:
+        # Wait for shutdown signal
+        await shutdown_event.wait()
+    finally:
+        await service.stop()
+
+
+def main(args: list[str] | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        args: Command line arguments (defaults to sys.argv[1:]).
+
+    Returns:
+        Exit code (0 for success, non-zero for error).
+    """
+    parsed = parse_args(args)
+    setup_logging(parsed.log_level)
+
+    logger = logging.getLogger(__name__)
+
+    # Create shutdown event
+    shutdown_event = asyncio.Event()
+
+    # Create service
+    service = WatcherService(
+        config_path=parsed.config.absolute(),
+        state_dir=parsed.state_dir.absolute(),
+        host=parsed.host,
+        port=parsed.port,
+    )
+
+    # Set up signal handlers
+    def signal_handler(signum: int, frame: object) -> None:
+        sig_name = signal.Signals(signum).name
+        logger.info(f"Received {sig_name}, initiating shutdown...")
+        shutdown_event.set()
+
+    # Register signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    logger.info(f"Config path: {parsed.config.absolute()}")
+    logger.info(f"State directory: {parsed.state_dir.absolute()}")
+    logger.info(f"Server will listen on http://{parsed.host}:{parsed.port}")
+
+    try:
+        asyncio.run(run_service(service, shutdown_event))
+        return 0
+    except Exception as e:
+        logger.error(f"Service error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude_session_player/watcher/service.py
+++ b/claude_session_player/watcher/service.py
@@ -1,0 +1,413 @@
+"""WatcherService class integrating all watcher components.
+
+This module provides the main orchestration service that wires together:
+- ConfigManager: persistent session configuration
+- StateManager: processing state persistence
+- FileWatcher: file change detection
+- Transformer: line-to-event processing
+- EventBufferManager: per-session event buffering
+- SSEManager: SSE event broadcasting
+- WatcherAPI: HTTP API endpoints
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+
+from claude_session_player.events import ProcessingContext
+from claude_session_player.watcher.api import WatcherAPI
+from claude_session_player.watcher.config import ConfigManager
+from claude_session_player.watcher.event_buffer import EventBufferManager
+from claude_session_player.watcher.file_watcher import FileWatcher
+from claude_session_player.watcher.sse import SSEManager
+from claude_session_player.watcher.state import SessionState, StateManager
+from claude_session_player.watcher.transformer import transform
+
+if TYPE_CHECKING:
+    from aiohttp.web import AppRunner, TCPSite
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WatcherService:
+    """Main service orchestrating all watcher components.
+
+    Handles lifecycle management (startup, shutdown) and event flow coordination
+    between file watcher, transformer, event buffer, and SSE manager.
+    """
+
+    config_path: Path
+    state_dir: Path
+
+    # Injected components (for testability)
+    config_manager: ConfigManager | None = None
+    state_manager: StateManager | None = None
+    file_watcher: FileWatcher | None = None
+    event_buffer: EventBufferManager | None = None
+    sse_manager: SSEManager | None = None
+    api: WatcherAPI | None = None
+
+    # HTTP server config
+    host: str = "127.0.0.1"
+    port: int = 8080
+
+    # Internal state
+    _runner: AppRunner | None = field(default=None, repr=False)
+    _site: TCPSite | None = field(default=None, repr=False)
+    _running: bool = field(default=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize components if not injected."""
+        # Create components if not provided (allows dependency injection for testing)
+        if self.config_manager is None:
+            self.config_manager = ConfigManager(self.config_path)
+
+        if self.state_manager is None:
+            self.state_manager = StateManager(self.state_dir)
+
+        if self.event_buffer is None:
+            self.event_buffer = EventBufferManager()
+
+        if self.sse_manager is None:
+            self.sse_manager = SSEManager(event_buffer=self.event_buffer)
+
+        if self.file_watcher is None:
+            self.file_watcher = FileWatcher(
+                on_lines_callback=self._on_file_change,
+                on_file_deleted_callback=self._on_file_deleted,
+            )
+
+        if self.api is None:
+            self.api = WatcherAPI(
+                config_manager=self.config_manager,
+                state_manager=self.state_manager,
+                file_watcher=self.file_watcher,
+                event_buffer=self.event_buffer,
+                sse_manager=self.sse_manager,
+            )
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the service is currently running."""
+        return self._running
+
+    async def start(self) -> None:
+        """Start the watcher service.
+
+        Startup sequence:
+        1. Load config.yaml
+        2. For each session in config:
+           - Load state (or create fresh if missing/corrupt)
+           - Validate file exists (remove from config if not)
+           - Add to FileWatcher with saved position
+        3. Start FileWatcher
+        4. Start HTTP server
+        """
+        if self._running:
+            logger.warning("Service already running")
+            return
+
+        logger.info("Starting watcher service...")
+
+        # Load existing config and resume sessions
+        await self._load_and_resume_sessions()
+
+        # Start file watcher
+        await self.file_watcher.start()
+        logger.info("File watcher started")
+
+        # Start HTTP server
+        app = self.api.create_app()
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        self._site = web.TCPSite(self._runner, self.host, self.port)
+        await self._site.start()
+
+        self._running = True
+        logger.info(f"HTTP server listening on http://{self.host}:{self.port}")
+
+    async def stop(self) -> None:
+        """Stop the watcher service gracefully.
+
+        Shutdown sequence:
+        1. Stop accepting new HTTP connections
+        2. Stop FileWatcher
+        3. Save all session states
+        4. Send session_ended to all SSE clients
+        5. Close all SSE connections
+        6. Exit
+        """
+        if not self._running:
+            return
+
+        logger.info("Stopping watcher service...")
+
+        # Stop HTTP server first
+        if self._site:
+            await self._site.stop()
+            self._site = None
+
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+
+        logger.info("HTTP server stopped")
+
+        # Stop file watcher
+        await self.file_watcher.stop()
+        logger.info("File watcher stopped")
+
+        # Save all session states
+        await self._save_all_states()
+        logger.info("All states saved")
+
+        # Close all SSE connections (send session_ended)
+        sessions = self.config_manager.list_all()
+        for session in sessions:
+            await self.sse_manager.close_session(session.session_id, reason="shutdown")
+
+        logger.info("All SSE connections closed")
+
+        self._running = False
+        logger.info("Watcher service stopped")
+
+    async def watch(self, session_id: str, path: Path) -> None:
+        """Add a session to be watched.
+
+        This is a higher-level method that coordinates all components.
+        The API layer uses this indirectly through its own handlers.
+
+        Args:
+            session_id: Unique identifier for the session.
+            path: Absolute path to the session JSONL file.
+
+        Raises:
+            ValueError: If session_id already exists or path is invalid.
+            FileNotFoundError: If path does not exist.
+        """
+        # Validate
+        if not path.is_absolute():
+            raise ValueError(f"Path must be absolute: {path}")
+        if not path.exists():
+            raise FileNotFoundError(f"Session file not found: {path}")
+
+        # Check for duplicate
+        if self.config_manager.get(session_id) is not None:
+            raise ValueError(f"Session already exists: {session_id}")
+
+        # Add to config
+        self.config_manager.add(session_id, path)
+
+        # Add to file watcher (start from end of file)
+        file_size = path.stat().st_size
+        self.file_watcher.add(session_id, path, start_position=file_size)
+
+        # Process initial lines for context
+        await self.file_watcher.process_initial(session_id, last_n_lines=3)
+
+        logger.info(f"Now watching session: {session_id}")
+
+    async def unwatch(self, session_id: str) -> None:
+        """Stop watching a session.
+
+        Coordinates cleanup across all components:
+        1. Notify SSE subscribers
+        2. Remove from file watcher
+        3. Remove event buffer
+        4. Delete state file
+        5. Remove from config
+
+        Args:
+            session_id: Identifier of the session to stop watching.
+
+        Raises:
+            KeyError: If session_id not found.
+        """
+        # Check if session exists
+        if self.config_manager.get(session_id) is None:
+            raise KeyError(f"Session not found: {session_id}")
+
+        # Emit session_ended event to SSE subscribers
+        await self.sse_manager.close_session(session_id, reason="unwatched")
+
+        # Remove from file watcher
+        self.file_watcher.remove(session_id)
+
+        # Remove event buffer
+        self.event_buffer.remove_buffer(session_id)
+
+        # Delete state file
+        self.state_manager.delete(session_id)
+
+        # Remove from config
+        self.config_manager.remove(session_id)
+
+        logger.info(f"Stopped watching session: {session_id}")
+
+    async def _load_and_resume_sessions(self) -> None:
+        """Load config and resume watching existing sessions.
+
+        For each session in config:
+        - Load state (or create fresh if missing/corrupt)
+        - Validate file exists (remove from config if not)
+        - Add to FileWatcher with saved position
+        """
+        sessions = self.config_manager.list_all()
+        sessions_to_remove: list[str] = []
+
+        for session in sessions:
+            session_id = session.session_id
+            path = session.path
+
+            # Validate file still exists
+            if not path.exists():
+                logger.warning(
+                    f"Session file no longer exists, removing: {session_id} ({path})"
+                )
+                sessions_to_remove.append(session_id)
+                continue
+
+            # Load state (or create fresh)
+            state = self.state_manager.load(session_id)
+            if state is None:
+                logger.info(f"No saved state for {session_id}, starting fresh")
+                # Start from end of file for new sessions
+                file_size = path.stat().st_size
+                start_position = file_size
+            else:
+                logger.info(
+                    f"Resuming {session_id} from position {state.file_position}"
+                )
+                start_position = state.file_position
+
+            # Add to file watcher
+            self.file_watcher.add(session_id, path, start_position=start_position)
+
+        # Remove sessions with missing files
+        for session_id in sessions_to_remove:
+            try:
+                self.config_manager.remove(session_id)
+                self.state_manager.delete(session_id)
+            except KeyError:
+                pass
+
+        logger.info(f"Loaded {len(sessions) - len(sessions_to_remove)} sessions")
+
+    async def _save_all_states(self) -> None:
+        """Save state for all active sessions."""
+        sessions = self.config_manager.list_all()
+
+        for session in sessions:
+            session_id = session.session_id
+
+            # Get current position from file watcher
+            position = self.file_watcher.get_position(session_id)
+            if position is None:
+                continue
+
+            # Load existing state to preserve context
+            existing_state = self.state_manager.load(session_id)
+            if existing_state is not None:
+                context = existing_state.processing_context
+                line_number = existing_state.line_number
+            else:
+                context = ProcessingContext()
+                line_number = 0
+
+            # Create updated state
+            state = SessionState(
+                file_position=position,
+                line_number=line_number,
+                processing_context=context,
+                last_modified=datetime.now(timezone.utc),
+            )
+
+            self.state_manager.save(session_id, state)
+
+    async def _on_file_change(self, session_id: str, lines: list[dict]) -> None:
+        """Handle file change callback from FileWatcher.
+
+        Event flow:
+        1. StateManager.load(session_id) → context
+        2. transform(lines, context) → events, new_context
+        3. StateManager.save(session_id, new_state)
+        4. for event in events:
+               EventBufferManager.add_event(session_id, event)
+               SSEManager.broadcast(session_id, event_id, event)
+
+        Args:
+            session_id: The session that changed.
+            lines: New parsed JSONL lines.
+        """
+        if not lines:
+            return
+
+        # Load existing state/context
+        state = self.state_manager.load(session_id)
+        if state is not None:
+            context = state.processing_context
+            line_number = state.line_number
+        else:
+            context = ProcessingContext()
+            line_number = 0
+
+        # Transform lines to events
+        events, new_context = transform(lines, context)
+
+        # Get current position from file watcher
+        position = self.file_watcher.get_position(session_id)
+        if position is None:
+            position = 0
+
+        # Update line number
+        new_line_number = line_number + len(lines)
+
+        # Save updated state
+        new_state = SessionState(
+            file_position=position,
+            line_number=new_line_number,
+            processing_context=new_context,
+            last_modified=datetime.now(timezone.utc),
+        )
+        self.state_manager.save(session_id, new_state)
+
+        # Buffer events and broadcast to SSE subscribers
+        for event in events:
+            event_id = self.event_buffer.add_event(session_id, event)
+            await self.sse_manager.broadcast(session_id, event_id, event)
+
+    async def _on_file_deleted(self, session_id: str) -> None:
+        """Handle file deletion callback from FileWatcher.
+
+        When a file is deleted:
+        1. Emit session_ended event to SSE subscribers
+        2. Remove from config
+        3. Delete state file
+        4. Remove event buffer
+
+        Args:
+            session_id: The session whose file was deleted.
+        """
+        logger.warning(f"Session file deleted: {session_id}")
+
+        # Notify SSE subscribers
+        await self.sse_manager.close_session(session_id, reason="file_deleted")
+
+        # Remove event buffer
+        self.event_buffer.remove_buffer(session_id)
+
+        # Delete state file
+        self.state_manager.delete(session_id)
+
+        # Remove from config
+        try:
+            self.config_manager.remove(session_id)
+        except KeyError:
+            pass

--- a/issues/worklogs/56-worklog.md
+++ b/issues/worklogs/56-worklog.md
@@ -1,0 +1,175 @@
+# Issue #56: Add WatcherService class integrating all components
+
+## Summary
+
+Implemented `WatcherService` class that orchestrates all watcher components (ConfigManager, StateManager, FileWatcher, transformer, EventBufferManager, SSEManager, WatcherAPI) with proper lifecycle management and event flow coordination. Also added CLI entry point with signal handling.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/service.py`**
+   - `WatcherService` dataclass with:
+     - `__init__(config_path, state_dir, host, port)` - initialization with optional dependency injection
+     - `start()` - async startup sequence
+     - `stop()` - async graceful shutdown
+     - `watch(session_id, path)` - add session to watch
+     - `unwatch(session_id)` - remove session from watch
+     - `_load_and_resume_sessions()` - load config and resume from saved state
+     - `_save_all_states()` - persist state for all sessions
+     - `_on_file_change(session_id, lines)` - handle file change events
+     - `_on_file_deleted(session_id)` - handle file deletion events
+     - `is_running` property for lifecycle state
+
+2. **`claude_session_player/watcher/__main__.py`**
+   - `parse_args()` - command line argument parsing
+   - `setup_logging()` - logging configuration
+   - `run_service()` - async service runner
+   - `main()` - CLI entry point
+   - Signal handling for SIGINT/SIGTERM
+   - Command-line args: `--host`, `--port`, `--config`, `--state-dir`, `--log-level`
+
+3. **`tests/watcher/test_service.py`**
+   - 41 comprehensive tests covering all functionality
+
+### Modified Files
+
+1. **`claude_session_player/watcher/__init__.py`**
+   - Added export for `WatcherService`
+
+## Design Decisions
+
+### Dependency Injection
+
+Components can be injected for testing, or auto-created:
+
+```python
+service = WatcherService(
+    config_path=Path("config.yaml"),
+    state_dir=Path("state"),
+    # Optional: inject components for testing
+    config_manager=mock_config_manager,
+)
+```
+
+### Event Flow
+
+```
+FileWatcher detects change
+    ↓
+_on_file_change(session_id, lines)
+    ↓
+StateManager.load(session_id) → context
+    ↓
+transform(lines, context) → events, new_context
+    ↓
+StateManager.save(session_id, new_state)
+    ↓
+for event in events:
+    EventBufferManager.add_event(session_id, event)
+    SSEManager.broadcast(session_id, event_id, event)
+```
+
+### Startup Sequence
+
+1. Load config.yaml
+2. For each session in config:
+   - Load state (or create fresh if missing/corrupt)
+   - Validate file exists (remove from config if not)
+   - Add to FileWatcher with saved position
+3. Start FileWatcher
+4. Start HTTP server
+
+### Shutdown Sequence
+
+1. Stop HTTP server
+2. Stop FileWatcher
+3. Save all session states
+4. Send `session_ended` to all SSE clients
+5. Close all SSE connections
+
+### Signal Handling
+
+CLI uses Python's `signal` module for clean shutdown:
+- SIGINT (Ctrl+C) → triggers shutdown
+- SIGTERM (kill signal) → triggers shutdown
+
+## Test Coverage
+
+41 tests organized by functionality:
+
+- **TestWatcherServiceCreation** (6 tests): Initialization and dependency injection
+- **TestWatcherServiceStartup** (5 tests): Startup sequence and state resumption
+- **TestWatcherServiceShutdown** (4 tests): Graceful shutdown and state saving
+- **TestWatcherServiceWatch** (5 tests): watch() method validation and behavior
+- **TestWatcherServiceUnwatch** (6 tests): unwatch() cleanup across components
+- **TestWatcherServiceFileChange** (4 tests): Event flow on file changes
+- **TestWatcherServiceFileDeletion** (4 tests): Handling of deleted files
+- **TestCorruptStateHandling** (1 test): Graceful recovery from corrupt state
+- **TestWatcherServiceIntegration** (3 tests): Full lifecycle and restart scenarios
+- **TestCLIMain** (3 tests): CLI argument parsing and logging setup
+
+## Test Results
+
+- **Before:** 751 tests total
+- **After:** 792 tests total (41 new)
+- All tests pass
+
+## Acceptance Criteria Status
+
+- [x] Service starts and loads existing config
+- [x] Service processes file changes end-to-end
+- [x] Watch/unwatch coordinate all components
+- [x] Graceful shutdown saves state
+- [x] CLI entry point works
+- [x] Signal handling for clean shutdown
+
+## Testing DoD Status
+
+- [x] Test service startup loads config
+- [x] Test service startup resumes from saved state
+- [x] Test file change triggers event flow
+- [x] Test watch() adds to all components
+- [x] Test unwatch() removes from all components + emits event
+- [x] Test shutdown saves state
+- [x] Test shutdown closes SSE connections
+- [x] Test corrupt state file handled (fresh context)
+- [x] Test missing file on startup removed from config
+- [x] Integration test: full lifecycle
+
+## Dependencies
+
+All dependencies from issues #48-#55 are utilized:
+- #48 (serialization) - via ProcessingContext.to_dict/from_dict
+- #49 (ConfigManager) - session configuration
+- #50 (StateManager) - state persistence
+- #51 (FileWatcher) - file change detection
+- #52 (transformer) - line-to-event processing
+- #53 (EventBuffer) - event buffering
+- #54 (SSE) - event broadcasting
+- #55 (API) - HTTP endpoints
+
+## Usage
+
+### Running the service
+
+```bash
+# Start with defaults
+python -m claude_session_player.watcher
+
+# Custom configuration
+python -m claude_session_player.watcher \
+    --host 0.0.0.0 \
+    --port 9000 \
+    --config /etc/watcher/config.yaml \
+    --state-dir /var/lib/watcher/state \
+    --log-level DEBUG
+```
+
+### API Endpoints
+
+- `POST /watch` - Add session to watch
+- `DELETE /unwatch/{session_id}` - Remove session
+- `GET /sessions` - List all sessions
+- `GET /sessions/{session_id}/events` - SSE stream
+- `GET /health` - Health check

--- a/tests/watcher/test_service.py
+++ b/tests/watcher/test_service.py
@@ -1,0 +1,907 @@
+"""Tests for the WatcherService class."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    ProcessingContext,
+    UpdateBlock,
+)
+from claude_session_player.watcher.config import ConfigManager
+from claude_session_player.watcher.event_buffer import EventBufferManager
+from claude_session_player.watcher.file_watcher import FileWatcher
+from claude_session_player.watcher.service import WatcherService
+from claude_session_player.watcher.sse import SSEManager
+from claude_session_player.watcher.state import SessionState, StateManager
+
+
+# --- Mock SSE Response ---
+
+
+@dataclass
+class MockStreamResponse:
+    """Mock streaming response for SSE testing."""
+
+    written: list[bytes] = field(default_factory=list)
+    prepared: bool = False
+    closed: bool = False
+
+    async def prepare(self, request: object) -> None:
+        """Prepare the response."""
+        self.prepared = True
+
+    async def write(self, data: bytes) -> None:
+        """Write data to response."""
+        if self.closed:
+            raise OSError("Connection closed")
+        self.written.append(data)
+
+    async def write_eof(self) -> None:
+        """Signal end of stream."""
+        self.closed = True
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def temp_config_path(tmp_path: Path) -> Path:
+    """Create a temporary config file path."""
+    return tmp_path / "config.yaml"
+
+
+@pytest.fixture
+def temp_state_dir(tmp_path: Path) -> Path:
+    """Create a temporary state directory."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    return state_dir
+
+
+@pytest.fixture
+def session_file(tmp_path: Path) -> Path:
+    """Create a temporary session file with content."""
+    session_path = tmp_path / "session.jsonl"
+    session_path.write_text('{"type":"user","message":{"content":"hello"}}\n')
+    return session_path
+
+
+@pytest.fixture
+def empty_session_file(tmp_path: Path) -> Path:
+    """Create an empty temporary session file."""
+    session_path = tmp_path / "empty_session.jsonl"
+    session_path.write_text("")
+    return session_path
+
+
+@pytest.fixture
+def watcher_service(
+    temp_config_path: Path,
+    temp_state_dir: Path,
+) -> WatcherService:
+    """Create a WatcherService instance for testing."""
+    return WatcherService(
+        config_path=temp_config_path,
+        state_dir=temp_state_dir,
+        host="127.0.0.1",
+        port=8888,  # Use non-standard port for tests
+    )
+
+
+# --- Tests for WatcherService creation ---
+
+
+class TestWatcherServiceCreation:
+    """Tests for WatcherService initialization."""
+
+    def test_creates_with_paths(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """WatcherService can be created with config and state paths."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+
+        assert service.config_path == temp_config_path
+        assert service.state_dir == temp_state_dir
+
+    def test_creates_default_components(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """WatcherService creates default components if not injected."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+
+        assert service.config_manager is not None
+        assert service.state_manager is not None
+        assert service.file_watcher is not None
+        assert service.event_buffer is not None
+        assert service.sse_manager is not None
+        assert service.api is not None
+
+    def test_accepts_injected_components(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """WatcherService accepts injected components for testing."""
+        config_manager = ConfigManager(temp_config_path)
+        state_manager = StateManager(temp_state_dir)
+        event_buffer = EventBufferManager()
+        sse_manager = SSEManager(event_buffer=event_buffer)
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            config_manager=config_manager,
+            state_manager=state_manager,
+            event_buffer=event_buffer,
+            sse_manager=sse_manager,
+        )
+
+        assert service.config_manager is config_manager
+        assert service.state_manager is state_manager
+        assert service.event_buffer is event_buffer
+        assert service.sse_manager is sse_manager
+
+    def test_default_host_and_port(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """WatcherService has default host and port."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+
+        assert service.host == "127.0.0.1"
+        assert service.port == 8080
+
+    def test_custom_host_and_port(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """WatcherService accepts custom host and port."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            host="0.0.0.0",
+            port=9090,
+        )
+
+        assert service.host == "0.0.0.0"
+        assert service.port == 9090
+
+    def test_is_running_initially_false(self, watcher_service: WatcherService) -> None:
+        """Service is not running initially."""
+        assert watcher_service.is_running is False
+
+
+# --- Tests for startup ---
+
+
+class TestWatcherServiceStartup:
+    """Tests for WatcherService startup."""
+
+    async def test_start_sets_running(self, watcher_service: WatcherService) -> None:
+        """Starting the service sets is_running to True."""
+        try:
+            await watcher_service.start()
+            assert watcher_service.is_running is True
+        finally:
+            await watcher_service.stop()
+
+    async def test_start_twice_is_noop(self, watcher_service: WatcherService) -> None:
+        """Starting an already running service is a no-op."""
+        try:
+            await watcher_service.start()
+            await watcher_service.start()  # Should not raise
+            assert watcher_service.is_running is True
+        finally:
+            await watcher_service.stop()
+
+    async def test_start_loads_existing_config(
+        self, temp_config_path: Path, temp_state_dir: Path, session_file: Path
+    ) -> None:
+        """Startup loads sessions from existing config."""
+        # Pre-populate config
+        config_manager = ConfigManager(temp_config_path)
+        config_manager.add("existing-session", session_file)
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8889,
+        )
+
+        try:
+            await service.start()
+
+            # Session should be in file watcher
+            assert "existing-session" in service.file_watcher.watched_sessions
+        finally:
+            await service.stop()
+
+    async def test_start_resumes_from_saved_state(
+        self, temp_config_path: Path, temp_state_dir: Path, session_file: Path
+    ) -> None:
+        """Startup resumes sessions from saved state."""
+        # Pre-populate config and state
+        config_manager = ConfigManager(temp_config_path)
+        config_manager.add("stateful-session", session_file)
+
+        state_manager = StateManager(temp_state_dir)
+        state = SessionState(
+            file_position=25,
+            line_number=1,
+            processing_context=ProcessingContext(),
+            last_modified=datetime.now(timezone.utc),
+        )
+        state_manager.save("stateful-session", state)
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8890,
+        )
+
+        try:
+            await service.start()
+
+            # File watcher should start at saved position
+            position = service.file_watcher.get_position("stateful-session")
+            assert position == 25
+        finally:
+            await service.stop()
+
+    async def test_start_removes_missing_files(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Startup removes sessions whose files no longer exist."""
+        # Create config pointing to nonexistent file
+        config_manager = ConfigManager(temp_config_path)
+        # Manually add a session with nonexistent path
+        from claude_session_player.watcher.config import SessionConfig
+
+        sessions = [SessionConfig(session_id="missing-file", path=Path("/nonexistent/path.jsonl"))]
+        config_manager.save(sessions)
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8891,
+        )
+
+        try:
+            await service.start()
+
+            # Session should be removed from config
+            assert config_manager.get("missing-file") is None
+        finally:
+            await service.stop()
+
+
+# --- Tests for shutdown ---
+
+
+class TestWatcherServiceShutdown:
+    """Tests for WatcherService shutdown."""
+
+    async def test_stop_clears_running(self, watcher_service: WatcherService) -> None:
+        """Stopping the service clears is_running."""
+        await watcher_service.start()
+        assert watcher_service.is_running is True
+
+        await watcher_service.stop()
+        assert watcher_service.is_running is False
+
+    async def test_stop_twice_is_noop(self, watcher_service: WatcherService) -> None:
+        """Stopping an already stopped service is a no-op."""
+        await watcher_service.start()
+        await watcher_service.stop()
+        await watcher_service.stop()  # Should not raise
+        assert watcher_service.is_running is False
+
+    async def test_shutdown_saves_state(
+        self, temp_config_path: Path, temp_state_dir: Path, session_file: Path
+    ) -> None:
+        """Shutdown saves state for all sessions."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8892,
+        )
+
+        try:
+            await service.start()
+
+            # Watch a session
+            await service.watch("save-test", session_file)
+
+            # Stop (should save state)
+            await service.stop()
+
+            # Verify state was saved
+            state = service.state_manager.load("save-test")
+            assert state is not None
+            assert state.file_position >= 0
+        finally:
+            if service.is_running:
+                await service.stop()
+
+    async def test_shutdown_closes_sse_connections(
+        self, temp_config_path: Path, temp_state_dir: Path, session_file: Path
+    ) -> None:
+        """Shutdown sends session_ended to SSE subscribers."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8893,
+        )
+
+        try:
+            await service.start()
+            await service.watch("sse-test", session_file)
+
+            # Simulate SSE connection
+            response = MockStreamResponse()
+            await service.sse_manager.connect("sse-test", response)
+
+            # Stop should send session_ended
+            await service.stop()
+
+            # Check that session_ended was sent
+            written = b"".join(response.written).decode("utf-8")
+            assert "session_ended" in written
+            assert "shutdown" in written
+        finally:
+            if service.is_running:
+                await service.stop()
+
+
+# --- Tests for watch() method ---
+
+
+class TestWatcherServiceWatch:
+    """Tests for WatcherService.watch() method."""
+
+    async def test_watch_adds_to_config(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """watch() adds session to config."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("watch-test", session_file)
+
+            config = watcher_service.config_manager.get("watch-test")
+            assert config is not None
+            assert config.session_id == "watch-test"
+        finally:
+            await watcher_service.stop()
+
+    async def test_watch_adds_to_file_watcher(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """watch() adds file to file watcher."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("fw-test", session_file)
+
+            assert "fw-test" in watcher_service.file_watcher.watched_sessions
+        finally:
+            await watcher_service.stop()
+
+    async def test_watch_validates_absolute_path(
+        self, watcher_service: WatcherService
+    ) -> None:
+        """watch() rejects relative paths."""
+        try:
+            await watcher_service.start()
+
+            with pytest.raises(ValueError, match="absolute"):
+                await watcher_service.watch("rel-test", Path("relative/path.jsonl"))
+        finally:
+            await watcher_service.stop()
+
+    async def test_watch_validates_file_exists(
+        self, watcher_service: WatcherService
+    ) -> None:
+        """watch() rejects nonexistent files."""
+        try:
+            await watcher_service.start()
+
+            with pytest.raises(FileNotFoundError):
+                await watcher_service.watch("missing-test", Path("/nonexistent/file.jsonl"))
+        finally:
+            await watcher_service.stop()
+
+    async def test_watch_rejects_duplicate(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """watch() rejects duplicate session IDs."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("dup-test", session_file)
+
+            with pytest.raises(ValueError, match="already exists"):
+                await watcher_service.watch("dup-test", session_file)
+        finally:
+            await watcher_service.stop()
+
+
+# --- Tests for unwatch() method ---
+
+
+class TestWatcherServiceUnwatch:
+    """Tests for WatcherService.unwatch() method."""
+
+    async def test_unwatch_removes_from_config(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """unwatch() removes session from config."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("unwatch-test", session_file)
+            await watcher_service.unwatch("unwatch-test")
+
+            assert watcher_service.config_manager.get("unwatch-test") is None
+        finally:
+            await watcher_service.stop()
+
+    async def test_unwatch_removes_from_file_watcher(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """unwatch() removes file from file watcher."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("fw-unwatch", session_file)
+            await watcher_service.unwatch("fw-unwatch")
+
+            assert "fw-unwatch" not in watcher_service.file_watcher.watched_sessions
+        finally:
+            await watcher_service.stop()
+
+    async def test_unwatch_removes_event_buffer(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """unwatch() removes event buffer."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("buffer-unwatch", session_file)
+
+            # Add an event
+            event = AddBlock(
+                block=Block(
+                    id="b1",
+                    type=BlockType.ASSISTANT,
+                    content=AssistantContent(text="test"),
+                )
+            )
+            watcher_service.event_buffer.add_event("buffer-unwatch", event)
+
+            await watcher_service.unwatch("buffer-unwatch")
+
+            # New buffer should be empty
+            buffer = watcher_service.event_buffer.get_buffer("buffer-unwatch")
+            assert len(buffer) == 0
+        finally:
+            await watcher_service.stop()
+
+    async def test_unwatch_deletes_state(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """unwatch() deletes state file."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("state-unwatch", session_file)
+
+            # Trigger state save by processing a file change
+            await watcher_service._on_file_change("state-unwatch", [{"type": "user"}])
+
+            assert watcher_service.state_manager.exists("state-unwatch")
+
+            await watcher_service.unwatch("state-unwatch")
+
+            assert not watcher_service.state_manager.exists("state-unwatch")
+        finally:
+            await watcher_service.stop()
+
+    async def test_unwatch_sends_session_ended(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """unwatch() sends session_ended to SSE subscribers."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("sse-unwatch", session_file)
+
+            # Connect SSE client
+            response = MockStreamResponse()
+            await watcher_service.sse_manager.connect("sse-unwatch", response)
+
+            await watcher_service.unwatch("sse-unwatch")
+
+            written = b"".join(response.written).decode("utf-8")
+            assert "session_ended" in written
+            assert "unwatched" in written
+        finally:
+            await watcher_service.stop()
+
+    async def test_unwatch_raises_for_unknown(
+        self, watcher_service: WatcherService
+    ) -> None:
+        """unwatch() raises KeyError for unknown session."""
+        try:
+            await watcher_service.start()
+
+            with pytest.raises(KeyError, match="not found"):
+                await watcher_service.unwatch("nonexistent")
+        finally:
+            await watcher_service.stop()
+
+
+# --- Tests for file change handling ---
+
+
+class TestWatcherServiceFileChange:
+    """Tests for file change event handling."""
+
+    async def test_file_change_triggers_event_flow(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File changes trigger the event processing flow."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("change-test", session_file)
+
+            # Simulate file change with a user message
+            lines = [{"type": "user", "message": {"content": "hello"}}]
+            await watcher_service._on_file_change("change-test", lines)
+
+            # Check that events were added to buffer
+            events = watcher_service.event_buffer.get_events_since("change-test", None)
+            assert len(events) > 0
+        finally:
+            await watcher_service.stop()
+
+    async def test_file_change_saves_state(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File changes save updated state."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("state-change", session_file)
+
+            # Simulate file change
+            lines = [{"type": "user", "message": {"content": "hello"}}]
+            await watcher_service._on_file_change("state-change", lines)
+
+            # Check state was saved
+            state = watcher_service.state_manager.load("state-change")
+            assert state is not None
+            assert state.line_number > 0
+        finally:
+            await watcher_service.stop()
+
+    async def test_file_change_broadcasts_events(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File changes broadcast events to SSE subscribers."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("broadcast-test", session_file)
+
+            # Connect SSE client
+            response = MockStreamResponse()
+            await watcher_service.sse_manager.connect("broadcast-test", response)
+
+            # Simulate file change with assistant message
+            lines = [{"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}]
+            await watcher_service._on_file_change("broadcast-test", lines)
+
+            # Check event was broadcast
+            written = b"".join(response.written).decode("utf-8")
+            assert "add_block" in written
+        finally:
+            await watcher_service.stop()
+
+    async def test_empty_lines_ignored(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """Empty lines list is ignored."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("empty-test", session_file)
+
+            # Simulate empty file change
+            await watcher_service._on_file_change("empty-test", [])
+
+            # No events should be added
+            events = watcher_service.event_buffer.get_events_since("empty-test", None)
+            assert len(events) == 0
+        finally:
+            await watcher_service.stop()
+
+
+# --- Tests for file deletion handling ---
+
+
+class TestWatcherServiceFileDeletion:
+    """Tests for file deletion handling."""
+
+    async def test_file_deleted_removes_from_config(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File deletion removes session from config."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("delete-config", session_file)
+
+            await watcher_service._on_file_deleted("delete-config")
+
+            assert watcher_service.config_manager.get("delete-config") is None
+        finally:
+            await watcher_service.stop()
+
+    async def test_file_deleted_sends_session_ended(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File deletion sends session_ended to SSE subscribers."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("delete-sse", session_file)
+
+            # Connect SSE client
+            response = MockStreamResponse()
+            await watcher_service.sse_manager.connect("delete-sse", response)
+
+            await watcher_service._on_file_deleted("delete-sse")
+
+            written = b"".join(response.written).decode("utf-8")
+            assert "session_ended" in written
+            assert "file_deleted" in written
+        finally:
+            await watcher_service.stop()
+
+    async def test_file_deleted_removes_buffer(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File deletion removes event buffer."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("delete-buffer", session_file)
+
+            # Add an event
+            event = AddBlock(
+                block=Block(
+                    id="b1",
+                    type=BlockType.ASSISTANT,
+                    content=AssistantContent(text="test"),
+                )
+            )
+            watcher_service.event_buffer.add_event("delete-buffer", event)
+
+            await watcher_service._on_file_deleted("delete-buffer")
+
+            # New buffer should be empty
+            buffer = watcher_service.event_buffer.get_buffer("delete-buffer")
+            assert len(buffer) == 0
+        finally:
+            await watcher_service.stop()
+
+    async def test_file_deleted_removes_state(
+        self, watcher_service: WatcherService, session_file: Path
+    ) -> None:
+        """File deletion removes state file."""
+        try:
+            await watcher_service.start()
+            await watcher_service.watch("delete-state", session_file)
+
+            # Trigger state save
+            await watcher_service._on_file_change("delete-state", [{"type": "user"}])
+            assert watcher_service.state_manager.exists("delete-state")
+
+            await watcher_service._on_file_deleted("delete-state")
+
+            assert not watcher_service.state_manager.exists("delete-state")
+        finally:
+            await watcher_service.stop()
+
+
+# --- Tests for corrupt state handling ---
+
+
+class TestCorruptStateHandling:
+    """Tests for handling corrupt state files."""
+
+    async def test_corrupt_state_uses_fresh_context(
+        self, temp_config_path: Path, temp_state_dir: Path, session_file: Path
+    ) -> None:
+        """Corrupt state file results in fresh context."""
+        # Pre-populate config
+        config_manager = ConfigManager(temp_config_path)
+        config_manager.add("corrupt-session", session_file)
+
+        # Write corrupt state file
+        state_file = temp_state_dir / "corrupt-session.json"
+        state_file.write_text("not valid json {{{")
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8894,
+        )
+
+        try:
+            await service.start()
+
+            # Session should still be watched (starting from end of file)
+            assert "corrupt-session" in service.file_watcher.watched_sessions
+        finally:
+            await service.stop()
+
+
+# --- Integration tests ---
+
+
+class TestWatcherServiceIntegration:
+    """Integration tests for full service lifecycle."""
+
+    async def test_full_lifecycle(
+        self, temp_config_path: Path, temp_state_dir: Path, tmp_path: Path
+    ) -> None:
+        """Test full service lifecycle: start → watch → unwatch → stop."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text('{"type":"user","message":{"content":"hello"}}\n')
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8895,
+        )
+
+        # Start
+        await service.start()
+        assert service.is_running
+
+        # Watch
+        await service.watch("lifecycle-test", session_file)
+        assert "lifecycle-test" in service.file_watcher.watched_sessions
+
+        # Unwatch
+        await service.unwatch("lifecycle-test")
+        assert "lifecycle-test" not in service.file_watcher.watched_sessions
+
+        # Stop
+        await service.stop()
+        assert not service.is_running
+
+    async def test_restart_resumes_state(
+        self, temp_config_path: Path, temp_state_dir: Path, tmp_path: Path
+    ) -> None:
+        """Service restart resumes from saved state."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text('{"type":"user"}\n{"type":"user"}\n')
+
+        # First service instance
+        service1 = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8896,
+        )
+
+        await service1.start()
+        await service1.watch("restart-test", session_file)
+
+        # Simulate processing some lines
+        await service1._on_file_change("restart-test", [{"type": "user"}])
+
+        await service1.stop()
+
+        # Second service instance
+        service2 = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8897,
+        )
+
+        await service2.start()
+
+        # Session should be loaded from config
+        assert "restart-test" in service2.file_watcher.watched_sessions
+
+        # State should be preserved
+        state = service2.state_manager.load("restart-test")
+        assert state is not None
+        assert state.line_number >= 1
+
+        await service2.stop()
+
+    async def test_multiple_sessions(
+        self, temp_config_path: Path, temp_state_dir: Path, tmp_path: Path
+    ) -> None:
+        """Service handles multiple sessions correctly."""
+        file1 = tmp_path / "session1.jsonl"
+        file2 = tmp_path / "session2.jsonl"
+        file1.write_text('{"type":"user"}\n')
+        file2.write_text('{"type":"user"}\n')
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            port=8898,
+        )
+
+        try:
+            await service.start()
+
+            await service.watch("session-1", file1)
+            await service.watch("session-2", file2)
+
+            assert len(service.config_manager.list_all()) == 2
+            assert "session-1" in service.file_watcher.watched_sessions
+            assert "session-2" in service.file_watcher.watched_sessions
+
+            # Unwatch one
+            await service.unwatch("session-1")
+
+            assert len(service.config_manager.list_all()) == 1
+            assert "session-1" not in service.file_watcher.watched_sessions
+            assert "session-2" in service.file_watcher.watched_sessions
+        finally:
+            await service.stop()
+
+
+# --- Tests for CLI entry point ---
+
+
+class TestCLIMain:
+    """Tests for CLI module functions."""
+
+    def test_parse_args_defaults(self) -> None:
+        """Default arguments are set correctly."""
+        from claude_session_player.watcher.__main__ import parse_args
+
+        args = parse_args([])
+
+        assert args.host == "127.0.0.1"
+        assert args.port == 8080
+        assert args.config == Path("config.yaml")
+        assert args.state_dir == Path("state")
+        assert args.log_level == "INFO"
+
+    def test_parse_args_custom_values(self) -> None:
+        """Custom arguments are parsed correctly."""
+        from claude_session_player.watcher.__main__ import parse_args
+
+        args = parse_args([
+            "--host", "0.0.0.0",
+            "--port", "9090",
+            "--config", "/etc/watcher/config.yaml",
+            "--state-dir", "/var/lib/watcher/state",
+            "--log-level", "DEBUG",
+        ])
+
+        assert args.host == "0.0.0.0"
+        assert args.port == 9090
+        assert args.config == Path("/etc/watcher/config.yaml")
+        assert args.state_dir == Path("/var/lib/watcher/state")
+        assert args.log_level == "DEBUG"
+
+    def test_setup_logging_runs_without_error(self) -> None:
+        """setup_logging runs without error for all log levels."""
+        from claude_session_player.watcher.__main__ import setup_logging
+
+        # Test all valid log levels run without error
+        for level in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+            setup_logging(level)  # Should not raise


### PR DESCRIPTION
## Summary

- Add `WatcherService` class that orchestrates all watcher components with proper lifecycle management
- Add CLI entry point (`python -m claude_session_player.watcher`) with signal handling
- Comprehensive test coverage (41 new tests)

## Components Integrated

- ConfigManager: persistent session configuration
- StateManager: processing state persistence
- FileWatcher: file change detection
- Transformer: line-to-event processing
- EventBufferManager: per-session event buffering
- SSEManager: SSE event broadcasting
- WatcherAPI: HTTP API endpoints

## Key Features

### Event Flow
```
FileWatcher detects change
    ↓
StateManager.load(session_id) → context
    ↓
transform(lines, context) → events, new_context
    ↓
StateManager.save(session_id, new_state)
    ↓
for event in events:
    EventBufferManager.add_event(session_id, event)
    SSEManager.broadcast(session_id, event_id, event)
```

### Lifecycle Management
- Startup: Load config, resume from saved state, start file watcher, start HTTP server
- Shutdown: Stop HTTP server, stop file watcher, save all states, close SSE connections

### CLI Usage
```bash
python -m claude_session_player.watcher \
    --host 0.0.0.0 \
    --port 9000 \
    --config /etc/watcher/config.yaml \
    --state-dir /var/lib/watcher/state \
    --log-level DEBUG
```

## Test plan

- [x] Test service startup loads config
- [x] Test service startup resumes from saved state
- [x] Test file change triggers event flow
- [x] Test watch() adds to all components
- [x] Test unwatch() removes from all components + emits event
- [x] Test shutdown saves state
- [x] Test shutdown closes SSE connections
- [x] Test corrupt state file handled (fresh context)
- [x] Test missing file on startup removed from config
- [x] Integration test: full lifecycle

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)