### PR TITLE
Issue #69: Update ConfigManager for destinations and bot credentials

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from claude_session_player.watcher.api import WatcherAPI
-from claude_session_player.watcher.config import ConfigManager, SessionConfig
+from claude_session_player.watcher.config import (
+    BotConfig,
+    ConfigManager,
+    SessionConfig,
+    SessionDestinations,
+    SlackDestination,
+    TelegramDestination,
+)
 from claude_session_player.watcher.deps import check_slack_available, check_telegram_available
 from claude_session_player.watcher.event_buffer import EventBuffer, EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalReader
@@ -13,6 +20,7 @@ from claude_session_player.watcher.state import SessionState, StateManager
 from claude_session_player.watcher.transformer import transform
 
 __all__ = [
+    "BotConfig",
     "check_slack_available",
     "check_telegram_available",
     "ConfigManager",
@@ -21,10 +29,13 @@ __all__ = [
     "FileWatcher",
     "IncrementalReader",
     "SessionConfig",
+    "SessionDestinations",
     "SessionState",
+    "SlackDestination",
     "SSEConnection",
     "SSEManager",
     "StateManager",
+    "TelegramDestination",
     "WatcherAPI",
     "WatcherService",
     "transform",

--- a/claude_session_player/watcher/config.py
+++ b/claude_session_player/watcher/config.py
@@ -4,10 +4,106 @@ from __future__ import annotations
 
 import os
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
+
+
+# ---------------------------------------------------------------------------
+# Destination dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TelegramDestination:
+    """A Telegram chat destination for session events."""
+
+    chat_id: str
+
+    def to_dict(self) -> dict:
+        """Serialize to dict for YAML storage."""
+        return {"chat_id": self.chat_id}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TelegramDestination:
+        """Deserialize from dict."""
+        return cls(chat_id=data["chat_id"])
+
+
+@dataclass
+class SlackDestination:
+    """A Slack channel destination for session events."""
+
+    channel: str  # Channel ID or name
+
+    def to_dict(self) -> dict:
+        """Serialize to dict for YAML storage."""
+        return {"channel": self.channel}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SlackDestination:
+        """Deserialize from dict."""
+        return cls(channel=data["channel"])
+
+
+@dataclass
+class SessionDestinations:
+    """Collection of messaging destinations for a session."""
+
+    telegram: list[TelegramDestination] = field(default_factory=list)
+    slack: list[SlackDestination] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Serialize to dict for YAML storage."""
+        return {
+            "telegram": [d.to_dict() for d in self.telegram],
+            "slack": [d.to_dict() for d in self.slack],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SessionDestinations:
+        """Deserialize from dict."""
+        telegram = [
+            TelegramDestination.from_dict(d) for d in data.get("telegram", [])
+        ]
+        slack = [SlackDestination.from_dict(d) for d in data.get("slack", [])]
+        return cls(telegram=telegram, slack=slack)
+
+
+@dataclass
+class BotConfig:
+    """Bot credentials configuration."""
+
+    telegram_token: str | None = None
+    slack_token: str | None = None
+
+    def to_dict(self) -> dict:
+        """Serialize to dict for YAML storage."""
+        result: dict = {}
+        if self.telegram_token is not None:
+            result["telegram"] = {"token": self.telegram_token}
+        if self.slack_token is not None:
+            result["slack"] = {"token": self.slack_token}
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BotConfig:
+        """Deserialize from dict."""
+        telegram_token = None
+        slack_token = None
+
+        if "telegram" in data and data["telegram"]:
+            telegram_token = data["telegram"].get("token")
+        if "slack" in data and data["slack"]:
+            slack_token = data["slack"].get("token")
+
+        return cls(telegram_token=telegram_token, slack_token=slack_token)
+
+
+# ---------------------------------------------------------------------------
+# SessionConfig dataclass
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -16,28 +112,87 @@ class SessionConfig:
 
     session_id: str
     path: Path
+    destinations: SessionDestinations = field(default_factory=SessionDestinations)
 
     def to_dict(self) -> dict:
-        """Serialize to dict for YAML storage."""
+        """Serialize to dict for YAML storage (old format for compatibility)."""
         return {
             "id": self.session_id,
             "path": str(self.path),
         }
 
+    def to_new_dict(self) -> dict:
+        """Serialize to dict for new YAML format."""
+        return {
+            "path": str(self.path),
+            "destinations": self.destinations.to_dict(),
+        }
+
     @classmethod
     def from_dict(cls, data: dict) -> SessionConfig:
-        """Deserialize from dict."""
+        """Deserialize from old format dict."""
         return cls(
             session_id=data["id"],
             path=Path(data["path"]),
+            destinations=SessionDestinations(),
         )
+
+    @classmethod
+    def from_new_dict(cls, session_id: str, data: dict) -> SessionConfig:
+        """Deserialize from new format dict."""
+        destinations = SessionDestinations()
+        if "destinations" in data:
+            destinations = SessionDestinations.from_dict(data["destinations"])
+        return cls(
+            session_id=session_id,
+            path=Path(data["path"]),
+            destinations=destinations,
+        )
+
+
+def _is_old_format(data: dict) -> bool:
+    """Check if the data is in the old config format.
+
+    Old format: {"sessions": [{"id": ..., "path": ...}, ...]}
+    New format: {"bots": {...}, "sessions": {"id": {"path": ..., "destinations": ...}}}
+    """
+    if "sessions" not in data:
+        return False
+    sessions = data["sessions"]
+    # Old format has sessions as a list
+    if isinstance(sessions, list):
+        return True
+    # New format has sessions as a dict
+    return False
+
+
+def _migrate_old_format(old_sessions: list[dict]) -> dict:
+    """Convert old format to new format.
+
+    Args:
+        old_sessions: List of session dicts from old format.
+
+    Returns:
+        New format dict with bots and sessions keys.
+    """
+    return {
+        "bots": {},
+        "sessions": {
+            item["id"]: {
+                "path": item["path"],
+                "destinations": {"telegram": [], "slack": []},
+            }
+            for item in old_sessions
+        },
+    }
 
 
 class ConfigManager:
     """Manages watched session files via config.yaml.
 
     Provides CRUD operations for session configurations with atomic writes
-    to prevent corruption.
+    to prevent corruption. Supports both old format (list of sessions) and
+    new format (dict with bots and sessions).
     """
 
     def __init__(self, config_path: Path) -> None:
@@ -47,6 +202,7 @@ class ConfigManager:
             config_path: Path to the YAML configuration file.
         """
         self._config_path = config_path
+        self._bot_config: BotConfig = BotConfig()
 
     @property
     def config_path(self) -> Path:
@@ -56,29 +212,60 @@ class ConfigManager:
     def load(self) -> list[SessionConfig]:
         """Load all session configurations from the YAML file.
 
+        Automatically migrates old format to new format in memory.
+        Bot config is cached and available via get_bot_config().
+
         Returns:
             List of SessionConfig objects. Empty list if file doesn't exist.
         """
         if not self._config_path.exists():
+            self._bot_config = BotConfig()
             return []
 
         with open(self._config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
-        if data is None or "sessions" not in data:
+        if data is None:
+            self._bot_config = BotConfig()
             return []
 
-        return [SessionConfig.from_dict(s) for s in data["sessions"]]
+        if "sessions" not in data:
+            # Load bot config even if no sessions
+            if "bots" in data:
+                self._bot_config = BotConfig.from_dict(data["bots"])
+            else:
+                self._bot_config = BotConfig()
+            return []
+
+        # Check if old format and migrate
+        if _is_old_format(data):
+            data = _migrate_old_format(data["sessions"])
+
+        # Load bot config
+        if "bots" in data:
+            self._bot_config = BotConfig.from_dict(data["bots"])
+        else:
+            self._bot_config = BotConfig()
+
+        # Load sessions from new format
+        sessions_data = data.get("sessions", {})
+        return [
+            SessionConfig.from_new_dict(session_id, session_data)
+            for session_id, session_data in sessions_data.items()
+        ]
 
     def save(self, sessions: list[SessionConfig]) -> None:
-        """Save session configurations to the YAML file.
+        """Save session configurations to the YAML file in new format.
 
         Uses atomic write (temp file + rename) to prevent corruption.
 
         Args:
             sessions: List of SessionConfig objects to save.
         """
-        data = {"sessions": [s.to_dict() for s in sessions]}
+        data: dict = {
+            "bots": self._bot_config.to_dict(),
+            "sessions": {s.session_id: s.to_new_dict() for s in sessions},
+        }
 
         # Ensure parent directory exists
         self._config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -100,6 +287,24 @@ class ConfigManager:
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
             raise
+
+    def get_bot_config(self) -> BotConfig:
+        """Return the current bot configuration.
+
+        Note: Call load() first to ensure bot config is up to date.
+
+        Returns:
+            BotConfig with telegram_token and slack_token.
+        """
+        return self._bot_config
+
+    def set_bot_config(self, bot_config: BotConfig) -> None:
+        """Set the bot configuration (in memory only, call save() to persist).
+
+        Args:
+            bot_config: New bot configuration.
+        """
+        self._bot_config = bot_config
 
     def add(self, session_id: str, path: Path) -> None:
         """Add a new session to the watch list.
@@ -174,3 +379,136 @@ class ConfigManager:
             List of all SessionConfig objects.
         """
         return self.load()
+
+    def get_destinations(self, session_id: str) -> SessionDestinations | None:
+        """Get the destinations for a session.
+
+        Args:
+            session_id: Identifier of the session.
+
+        Returns:
+            SessionDestinations if session found, None otherwise.
+        """
+        session = self.get(session_id)
+        if session is None:
+            return None
+        return session.destinations
+
+    def add_destination(
+        self,
+        session_id: str,
+        destination: TelegramDestination | SlackDestination,
+        path: Path | None = None,
+    ) -> bool:
+        """Add a destination to a session.
+
+        If the session doesn't exist and path is provided, creates the session.
+        Idempotent: returns True without changes if destination already exists.
+
+        Args:
+            session_id: Identifier of the session.
+            destination: TelegramDestination or SlackDestination to add.
+            path: Path to session file (required if session doesn't exist).
+
+        Returns:
+            True if destination was added or already exists, False if session
+            doesn't exist and no path provided.
+
+        Raises:
+            ValueError: If destination has empty chat_id or channel.
+            ValueError: If path is not absolute (when provided).
+            FileNotFoundError: If path does not exist (when provided).
+        """
+        # Validate destination
+        if isinstance(destination, TelegramDestination):
+            if not destination.chat_id:
+                raise ValueError("Telegram chat_id must be non-empty")
+        elif isinstance(destination, SlackDestination):
+            if not destination.channel:
+                raise ValueError("Slack channel must be non-empty")
+
+        sessions = self.load()
+
+        # Find or create session
+        session = None
+        for s in sessions:
+            if s.session_id == session_id:
+                session = s
+                break
+
+        if session is None:
+            if path is None:
+                return False
+            # Validate path
+            if not path.is_absolute():
+                raise ValueError(f"Path must be absolute: {path}")
+            if not path.exists():
+                raise FileNotFoundError(f"Session file not found: {path}")
+            session = SessionConfig(session_id=session_id, path=path)
+            sessions.append(session)
+
+        # Add destination (idempotent)
+        if isinstance(destination, TelegramDestination):
+            # Check if already exists
+            for existing in session.destinations.telegram:
+                if existing.chat_id == destination.chat_id:
+                    return True  # Already exists
+            session.destinations.telegram.append(destination)
+        else:  # SlackDestination
+            # Check if already exists
+            for existing in session.destinations.slack:
+                if existing.channel == destination.channel:
+                    return True  # Already exists
+            session.destinations.slack.append(destination)
+
+        self.save(sessions)
+        return True
+
+    def remove_destination(
+        self,
+        session_id: str,
+        destination: TelegramDestination | SlackDestination,
+    ) -> bool:
+        """Remove a destination from a session.
+
+        Args:
+            session_id: Identifier of the session.
+            destination: TelegramDestination or SlackDestination to remove.
+
+        Returns:
+            True if destination was removed, False if not found.
+        """
+        sessions = self.load()
+
+        # Find session
+        session = None
+        for s in sessions:
+            if s.session_id == session_id:
+                session = s
+                break
+
+        if session is None:
+            return False
+
+        # Remove destination
+        if isinstance(destination, TelegramDestination):
+            original_count = len(session.destinations.telegram)
+            session.destinations.telegram = [
+                d
+                for d in session.destinations.telegram
+                if d.chat_id != destination.chat_id
+            ]
+            if len(session.destinations.telegram) == original_count:
+                return False
+        else:  # SlackDestination
+            original_count = len(session.destinations.slack)
+            session.destinations.slack = [
+                d
+                for d in session.destinations.slack
+                if d.channel != destination.channel
+            ]
+            if len(session.destinations.slack) == original_count:
+                return False
+
+        self.save(sessions)
+        return True

--- a/issues/worklogs/69-worklog.md
+++ b/issues/worklogs/69-worklog.md
@@ -1,0 +1,139 @@
+# Issue #69: Update ConfigManager for destinations and bot credentials
+
+## Summary
+
+Updated `ConfigManager` to support the new config schema with bot credentials and per-session messaging destinations. The implementation provides full backward compatibility with the old config format through automatic migration.
+
+## Changes Made
+
+### Modified Files
+
+1. **`claude_session_player/watcher/config.py`**
+   - Added `TelegramDestination` dataclass with `chat_id` field
+   - Added `SlackDestination` dataclass with `channel` field
+   - Added `SessionDestinations` dataclass to hold lists of destinations
+   - Added `BotConfig` dataclass for telegram/slack bot tokens
+   - Updated `SessionConfig` to include `destinations` field with default empty
+   - Added `to_new_dict()` and `from_new_dict()` methods to `SessionConfig`
+   - Added `_is_old_format()` helper function for format detection
+   - Added `_migrate_old_format()` helper function for migration
+   - Updated `ConfigManager.load()` to handle both old and new formats
+   - Updated `ConfigManager.save()` to always write new format
+   - Added `ConfigManager.get_bot_config()` to return cached bot config
+   - Added `ConfigManager.set_bot_config()` to update bot config in memory
+   - Added `ConfigManager.get_destinations()` to get session destinations
+   - Added `ConfigManager.add_destination()` for adding destinations (idempotent)
+   - Added `ConfigManager.remove_destination()` for removing destinations
+
+2. **`claude_session_player/watcher/__init__.py`**
+   - Added exports for `BotConfig`, `SessionDestinations`, `TelegramDestination`, `SlackDestination`
+   - Updated `__all__` list
+
+3. **`tests/watcher/test_config.py`**
+   - Added 58 new tests for new dataclasses and ConfigManager methods
+   - Tests cover: TelegramDestination, SlackDestination, SessionDestinations, BotConfig
+   - Tests cover: old format loading, new format loading, migration behavior
+   - Tests cover: add_destination, remove_destination, get_destinations
+   - Tests cover: idempotent add, validation of empty chat_id/channel
+
+## Design Decisions
+
+### Config Format Migration
+
+The migration happens transparently in memory during `load()`:
+- Old format is detected by checking if `sessions` is a list vs dict
+- Old sessions are converted with empty destinations
+- The file is NOT automatically rewritten - only `save()` writes new format
+- This allows for safe testing and gradual migration
+
+### Bot Config Caching
+
+Bot configuration is cached in the `ConfigManager` instance after `load()`:
+- `get_bot_config()` returns the cached config
+- `set_bot_config()` updates the in-memory config
+- The config is persisted to file when `save()` is called
+
+### Idempotent Destination Operations
+
+- `add_destination()` checks for duplicate chat_id/channel before adding
+- Adding the same destination twice returns `True` without creating duplicates
+- `remove_destination()` returns `False` if destination not found (no error)
+
+### Validation
+
+- Telegram `chat_id` must be non-empty string
+- Slack `channel` must be non-empty string
+- When creating session via `add_destination()`, path validation follows existing rules
+
+## Config Format Examples
+
+### Old Format (still supported for reading)
+```yaml
+sessions:
+  - id: "session-001"
+    path: "/path/to/file.jsonl"
+```
+
+### New Format (always written)
+```yaml
+bots:
+  telegram:
+    token: "BOT_TOKEN"
+  slack:
+    token: "xoxb-..."
+sessions:
+  session-001:
+    path: "/path/to/file.jsonl"
+    destinations:
+      telegram:
+        - chat_id: "123456789"
+      slack:
+        - channel: "C0123456789"
+```
+
+## Test Coverage
+
+| Test Class | Tests | Coverage |
+|------------|-------|----------|
+| TestTelegramDestination | 4 | dataclass methods |
+| TestSlackDestination | 4 | dataclass methods |
+| TestSessionDestinations | 6 | dataclass methods |
+| TestBotConfig | 9 | dataclass methods |
+| TestSessionConfig | 9 | existing + new format methods |
+| TestConfigManagerOldFormat | 3 | old format loading/migration |
+| TestConfigManagerSaveFormat | 2 | new format saving |
+| TestConfigManagerBotConfig | 4 | bot config methods |
+| TestConfigManagerGetDestinations | 3 | get_destinations() |
+| TestConfigManagerAddDestination | 11 | add_destination() |
+| TestConfigManagerRemoveDestination | 5 | remove_destination() |
+| TestConfigMigrationRoundtrip | 2 | full migration flow |
+
+## Test Results
+
+- **Before:** 826 tests
+- **After:** 884 tests (58 new)
+- All tests pass
+
+## Acceptance Criteria Status
+
+- [x] New dataclasses defined in `config.py`
+- [x] `load()` handles both old and new config formats
+- [x] Old format auto-migrated on load (in memory, not written back until `save()`)
+- [x] `save()` writes new format
+- [x] `add_destination()` and `remove_destination()` methods work correctly
+- [x] `get_bot_config()` returns bot credentials
+- [x] Unit tests cover:
+  - [x] Loading old format config
+  - [x] Loading new format config
+  - [x] Adding/removing telegram destinations
+  - [x] Adding/removing slack destinations
+  - [x] Idempotent add (no duplicates)
+  - [x] Empty destinations by default
+- [x] Existing tests still pass
+
+## Spec Reference
+
+Implements issue #69 from `.claude/specs/messaging-integration.md`:
+- Updated config schema for bot credentials
+- Per-session destination lists
+- Backward compatibility with existing config files

--- a/tests/watcher/test_config.py
+++ b/tests/watcher/test_config.py
@@ -7,7 +7,224 @@ from pathlib import Path
 
 import pytest
 
-from claude_session_player.watcher.config import ConfigManager, SessionConfig
+from claude_session_player.watcher.config import (
+    BotConfig,
+    ConfigManager,
+    SessionConfig,
+    SessionDestinations,
+    SlackDestination,
+    TelegramDestination,
+)
+
+
+# ---------------------------------------------------------------------------
+# TelegramDestination tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramDestination:
+    """Tests for TelegramDestination dataclass."""
+
+    def test_create_telegram_destination(self) -> None:
+        """Can create TelegramDestination with chat_id."""
+        dest = TelegramDestination(chat_id="123456789")
+        assert dest.chat_id == "123456789"
+
+    def test_to_dict(self) -> None:
+        """to_dict returns expected structure."""
+        dest = TelegramDestination(chat_id="123456789")
+        result = dest.to_dict()
+        assert result == {"chat_id": "123456789"}
+
+    def test_from_dict(self) -> None:
+        """from_dict reconstructs TelegramDestination correctly."""
+        data = {"chat_id": "123456789"}
+        dest = TelegramDestination.from_dict(data)
+        assert dest.chat_id == "123456789"
+
+    def test_roundtrip(self) -> None:
+        """to_dict/from_dict round-trip preserves data."""
+        original = TelegramDestination(chat_id="-100987654321")
+        restored = TelegramDestination.from_dict(original.to_dict())
+        assert restored.chat_id == original.chat_id
+
+
+# ---------------------------------------------------------------------------
+# SlackDestination tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlackDestination:
+    """Tests for SlackDestination dataclass."""
+
+    def test_create_slack_destination(self) -> None:
+        """Can create SlackDestination with channel."""
+        dest = SlackDestination(channel="C0123456789")
+        assert dest.channel == "C0123456789"
+
+    def test_to_dict(self) -> None:
+        """to_dict returns expected structure."""
+        dest = SlackDestination(channel="C0123456789")
+        result = dest.to_dict()
+        assert result == {"channel": "C0123456789"}
+
+    def test_from_dict(self) -> None:
+        """from_dict reconstructs SlackDestination correctly."""
+        data = {"channel": "C0123456789"}
+        dest = SlackDestination.from_dict(data)
+        assert dest.channel == "C0123456789"
+
+    def test_roundtrip(self) -> None:
+        """to_dict/from_dict round-trip preserves data."""
+        original = SlackDestination(channel="general")
+        restored = SlackDestination.from_dict(original.to_dict())
+        assert restored.channel == original.channel
+
+
+# ---------------------------------------------------------------------------
+# SessionDestinations tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionDestinations:
+    """Tests for SessionDestinations dataclass."""
+
+    def test_create_empty_destinations(self) -> None:
+        """Default destinations are empty lists."""
+        dest = SessionDestinations()
+        assert dest.telegram == []
+        assert dest.slack == []
+
+    def test_create_with_destinations(self) -> None:
+        """Can create with telegram and slack destinations."""
+        telegram = [TelegramDestination(chat_id="123")]
+        slack = [SlackDestination(channel="C123")]
+        dest = SessionDestinations(telegram=telegram, slack=slack)
+        assert len(dest.telegram) == 1
+        assert len(dest.slack) == 1
+        assert dest.telegram[0].chat_id == "123"
+        assert dest.slack[0].channel == "C123"
+
+    def test_to_dict(self) -> None:
+        """to_dict returns expected structure."""
+        dest = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123")],
+        )
+        result = dest.to_dict()
+        assert result == {
+            "telegram": [{"chat_id": "123"}],
+            "slack": [{"channel": "C123"}],
+        }
+
+    def test_from_dict(self) -> None:
+        """from_dict reconstructs SessionDestinations correctly."""
+        data = {
+            "telegram": [{"chat_id": "123"}, {"chat_id": "456"}],
+            "slack": [{"channel": "C123"}],
+        }
+        dest = SessionDestinations.from_dict(data)
+        assert len(dest.telegram) == 2
+        assert len(dest.slack) == 1
+        assert dest.telegram[0].chat_id == "123"
+        assert dest.telegram[1].chat_id == "456"
+        assert dest.slack[0].channel == "C123"
+
+    def test_from_dict_empty(self) -> None:
+        """from_dict handles empty/missing keys."""
+        dest = SessionDestinations.from_dict({})
+        assert dest.telegram == []
+        assert dest.slack == []
+
+    def test_roundtrip(self) -> None:
+        """to_dict/from_dict round-trip preserves data."""
+        original = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123"), SlackDestination(channel="C456")],
+        )
+        restored = SessionDestinations.from_dict(original.to_dict())
+        assert len(restored.telegram) == len(original.telegram)
+        assert len(restored.slack) == len(original.slack)
+
+
+# ---------------------------------------------------------------------------
+# BotConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestBotConfig:
+    """Tests for BotConfig dataclass."""
+
+    def test_create_empty_bot_config(self) -> None:
+        """Default bot config has no tokens."""
+        config = BotConfig()
+        assert config.telegram_token is None
+        assert config.slack_token is None
+
+    def test_create_with_tokens(self) -> None:
+        """Can create with telegram and slack tokens."""
+        config = BotConfig(
+            telegram_token="BOT_TOKEN",
+            slack_token="xoxb-token",
+        )
+        assert config.telegram_token == "BOT_TOKEN"
+        assert config.slack_token == "xoxb-token"
+
+    def test_to_dict_with_tokens(self) -> None:
+        """to_dict includes configured tokens."""
+        config = BotConfig(
+            telegram_token="BOT_TOKEN",
+            slack_token="xoxb-token",
+        )
+        result = config.to_dict()
+        assert result == {
+            "telegram": {"token": "BOT_TOKEN"},
+            "slack": {"token": "xoxb-token"},
+        }
+
+    def test_to_dict_empty(self) -> None:
+        """to_dict returns empty dict when no tokens."""
+        config = BotConfig()
+        result = config.to_dict()
+        assert result == {}
+
+    def test_to_dict_partial(self) -> None:
+        """to_dict only includes configured tokens."""
+        config = BotConfig(telegram_token="BOT_TOKEN")
+        result = config.to_dict()
+        assert result == {"telegram": {"token": "BOT_TOKEN"}}
+
+    def test_from_dict_with_tokens(self) -> None:
+        """from_dict reconstructs BotConfig correctly."""
+        data = {
+            "telegram": {"token": "BOT_TOKEN"},
+            "slack": {"token": "xoxb-token"},
+        }
+        config = BotConfig.from_dict(data)
+        assert config.telegram_token == "BOT_TOKEN"
+        assert config.slack_token == "xoxb-token"
+
+    def test_from_dict_empty(self) -> None:
+        """from_dict handles empty dict."""
+        config = BotConfig.from_dict({})
+        assert config.telegram_token is None
+        assert config.slack_token is None
+
+    def test_from_dict_partial(self) -> None:
+        """from_dict handles partial config."""
+        config = BotConfig.from_dict({"slack": {"token": "xoxb-token"}})
+        assert config.telegram_token is None
+        assert config.slack_token == "xoxb-token"
+
+    def test_roundtrip(self) -> None:
+        """to_dict/from_dict round-trip preserves data."""
+        original = BotConfig(
+            telegram_token="BOT_TOKEN",
+            slack_token="xoxb-token",
+        )
+        restored = BotConfig.from_dict(original.to_dict())
+        assert restored.telegram_token == original.telegram_token
+        assert restored.slack_token == original.slack_token
 
 
 # ---------------------------------------------------------------------------
@@ -27,8 +244,31 @@ class TestSessionConfig:
         assert config.session_id == "test-session-001"
         assert config.path == Path("/path/to/session.jsonl")
 
+    def test_create_with_empty_destinations_by_default(self) -> None:
+        """SessionConfig has empty destinations by default."""
+        config = SessionConfig(
+            session_id="test-session-001",
+            path=Path("/path/to/session.jsonl"),
+        )
+        assert config.destinations.telegram == []
+        assert config.destinations.slack == []
+
+    def test_create_with_destinations(self) -> None:
+        """Can create SessionConfig with destinations."""
+        destinations = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123")],
+        )
+        config = SessionConfig(
+            session_id="test-session-001",
+            path=Path("/path/to/session.jsonl"),
+            destinations=destinations,
+        )
+        assert len(config.destinations.telegram) == 1
+        assert len(config.destinations.slack) == 1
+
     def test_to_dict(self) -> None:
-        """to_dict returns expected structure."""
+        """to_dict returns expected structure (old format)."""
         config = SessionConfig(
             session_id="test-session-001",
             path=Path("/path/to/session.jsonl"),
@@ -39,8 +279,28 @@ class TestSessionConfig:
             "path": "/path/to/session.jsonl",
         }
 
+    def test_to_new_dict(self) -> None:
+        """to_new_dict returns new format structure."""
+        destinations = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123")],
+        )
+        config = SessionConfig(
+            session_id="test-session-001",
+            path=Path("/path/to/session.jsonl"),
+            destinations=destinations,
+        )
+        result = config.to_new_dict()
+        assert result == {
+            "path": "/path/to/session.jsonl",
+            "destinations": {
+                "telegram": [{"chat_id": "123"}],
+                "slack": [{"channel": "C123"}],
+            },
+        }
+
     def test_from_dict(self) -> None:
-        """from_dict reconstructs SessionConfig correctly."""
+        """from_dict reconstructs SessionConfig from old format."""
         data = {
             "id": "test-session-001",
             "path": "/path/to/session.jsonl",
@@ -48,6 +308,30 @@ class TestSessionConfig:
         config = SessionConfig.from_dict(data)
         assert config.session_id == "test-session-001"
         assert config.path == Path("/path/to/session.jsonl")
+        assert config.destinations.telegram == []
+        assert config.destinations.slack == []
+
+    def test_from_new_dict(self) -> None:
+        """from_new_dict reconstructs SessionConfig from new format."""
+        data = {
+            "path": "/path/to/session.jsonl",
+            "destinations": {
+                "telegram": [{"chat_id": "123"}],
+                "slack": [{"channel": "C123"}],
+            },
+        }
+        config = SessionConfig.from_new_dict("test-session-001", data)
+        assert config.session_id == "test-session-001"
+        assert config.path == Path("/path/to/session.jsonl")
+        assert len(config.destinations.telegram) == 1
+        assert len(config.destinations.slack) == 1
+
+    def test_from_new_dict_no_destinations(self) -> None:
+        """from_new_dict handles missing destinations."""
+        data = {"path": "/path/to/session.jsonl"}
+        config = SessionConfig.from_new_dict("test-session-001", data)
+        assert config.destinations.telegram == []
+        assert config.destinations.slack == []
 
     def test_roundtrip(self) -> None:
         """to_dict/from_dict round-trip preserves data."""
@@ -515,3 +799,658 @@ class TestAtomicWrite:
         """config_path property returns the configuration file path."""
         manager = ConfigManager(tmp_config_path)
         assert manager.config_path == tmp_config_path
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager old format migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerOldFormat:
+    """Tests for loading and migrating old config format."""
+
+    def test_load_old_format_config(
+        self, config_manager: ConfigManager, tmp_config_path: Path
+    ) -> None:
+        """load() correctly parses old format config."""
+        yaml_content = """sessions:
+  - id: "session-001"
+    path: "/path/to/first.jsonl"
+  - id: "session-002"
+    path: "/path/to/second.jsonl"
+"""
+        tmp_config_path.write_text(yaml_content)
+        sessions = config_manager.load()
+
+        assert len(sessions) == 2
+        assert sessions[0].session_id == "session-001"
+        assert sessions[0].path == Path("/path/to/first.jsonl")
+        # Old format should result in empty destinations
+        assert sessions[0].destinations.telegram == []
+        assert sessions[0].destinations.slack == []
+
+    def test_load_new_format_config(
+        self, config_manager: ConfigManager, tmp_config_path: Path
+    ) -> None:
+        """load() correctly parses new format config."""
+        yaml_content = """bots:
+  telegram:
+    token: "BOT_TOKEN"
+  slack:
+    token: "xoxb-token"
+sessions:
+  session-001:
+    path: "/path/to/first.jsonl"
+    destinations:
+      telegram:
+        - chat_id: "123456789"
+      slack:
+        - channel: "C0123456789"
+  session-002:
+    path: "/path/to/second.jsonl"
+    destinations:
+      telegram: []
+      slack: []
+"""
+        tmp_config_path.write_text(yaml_content)
+        sessions = config_manager.load()
+
+        assert len(sessions) == 2
+
+        # Check session with destinations
+        session_001 = next(s for s in sessions if s.session_id == "session-001")
+        assert session_001.path == Path("/path/to/first.jsonl")
+        assert len(session_001.destinations.telegram) == 1
+        assert session_001.destinations.telegram[0].chat_id == "123456789"
+        assert len(session_001.destinations.slack) == 1
+        assert session_001.destinations.slack[0].channel == "C0123456789"
+
+        # Check session without destinations
+        session_002 = next(s for s in sessions if s.session_id == "session-002")
+        assert session_002.destinations.telegram == []
+        assert session_002.destinations.slack == []
+
+        # Check bot config
+        bot_config = config_manager.get_bot_config()
+        assert bot_config.telegram_token == "BOT_TOKEN"
+        assert bot_config.slack_token == "xoxb-token"
+
+    def test_migration_does_not_write_file(
+        self, config_manager: ConfigManager, tmp_config_path: Path
+    ) -> None:
+        """Loading old format does not auto-migrate on disk."""
+        yaml_content = """sessions:
+  - id: "session-001"
+    path: "/path/to/first.jsonl"
+"""
+        tmp_config_path.write_text(yaml_content)
+        config_manager.load()
+
+        # File should still be in old format
+        content = tmp_config_path.read_text()
+        assert "- id:" in content
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager save format tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerSaveFormat:
+    """Tests for saving in new config format."""
+
+    def test_save_writes_new_format(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+        tmp_config_path: Path,
+    ) -> None:
+        """save() writes config in new format."""
+        destinations = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123")],
+        )
+        sessions = [
+            SessionConfig(
+                session_id="test-session",
+                path=sample_session_file,
+                destinations=destinations,
+            )
+        ]
+        config_manager.save(sessions)
+
+        content = tmp_config_path.read_text()
+        # New format uses session_id as key, not "- id:"
+        assert "test-session:" in content
+        assert "- id:" not in content
+        assert "destinations:" in content
+        assert "chat_id:" in content
+        assert "channel:" in content
+
+    def test_save_includes_bot_config(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+        tmp_config_path: Path,
+    ) -> None:
+        """save() includes bot configuration."""
+        config_manager.set_bot_config(
+            BotConfig(telegram_token="BOT_TOKEN", slack_token="xoxb-token")
+        )
+        sessions = [
+            SessionConfig(session_id="test-session", path=sample_session_file)
+        ]
+        config_manager.save(sessions)
+
+        content = tmp_config_path.read_text()
+        assert "bots:" in content
+        assert "BOT_TOKEN" in content
+        assert "xoxb-token" in content
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager bot config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerBotConfig:
+    """Tests for bot configuration methods."""
+
+    def test_get_bot_config_empty(
+        self, config_manager: ConfigManager
+    ) -> None:
+        """get_bot_config returns empty config when no file."""
+        config_manager.load()
+        bot_config = config_manager.get_bot_config()
+        assert bot_config.telegram_token is None
+        assert bot_config.slack_token is None
+
+    def test_get_bot_config_from_file(
+        self, config_manager: ConfigManager, tmp_config_path: Path
+    ) -> None:
+        """get_bot_config returns tokens from config file."""
+        yaml_content = """bots:
+  telegram:
+    token: "BOT_TOKEN"
+  slack:
+    token: "xoxb-token"
+sessions: {}
+"""
+        tmp_config_path.write_text(yaml_content)
+        config_manager.load()
+
+        bot_config = config_manager.get_bot_config()
+        assert bot_config.telegram_token == "BOT_TOKEN"
+        assert bot_config.slack_token == "xoxb-token"
+
+    def test_set_bot_config(
+        self, config_manager: ConfigManager
+    ) -> None:
+        """set_bot_config updates in-memory config."""
+        new_config = BotConfig(telegram_token="NEW_TOKEN")
+        config_manager.set_bot_config(new_config)
+
+        bot_config = config_manager.get_bot_config()
+        assert bot_config.telegram_token == "NEW_TOKEN"
+        assert bot_config.slack_token is None
+
+    def test_bot_config_persists_on_save(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+        tmp_config_path: Path,
+    ) -> None:
+        """Bot config is persisted when save() is called."""
+        config_manager.set_bot_config(BotConfig(telegram_token="BOT_TOKEN"))
+        config_manager.save(
+            [SessionConfig(session_id="test", path=sample_session_file)]
+        )
+
+        # Create new manager and load
+        new_manager = ConfigManager(tmp_config_path)
+        new_manager.load()
+        bot_config = new_manager.get_bot_config()
+        assert bot_config.telegram_token == "BOT_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager get_destinations tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerGetDestinations:
+    """Tests for ConfigManager.get_destinations()."""
+
+    def test_get_destinations_returns_destinations(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """get_destinations returns SessionDestinations for existing session."""
+        destinations = SessionDestinations(
+            telegram=[TelegramDestination(chat_id="123")],
+            slack=[SlackDestination(channel="C123")],
+        )
+        sessions = [
+            SessionConfig(
+                session_id="test-session",
+                path=sample_session_file,
+                destinations=destinations,
+            )
+        ]
+        config_manager.save(sessions)
+
+        result = config_manager.get_destinations("test-session")
+        assert result is not None
+        assert len(result.telegram) == 1
+        assert result.telegram[0].chat_id == "123"
+        assert len(result.slack) == 1
+        assert result.slack[0].channel == "C123"
+
+    def test_get_destinations_returns_none_for_nonexistent(
+        self, config_manager: ConfigManager
+    ) -> None:
+        """get_destinations returns None for non-existent session."""
+        config_manager.load()
+        result = config_manager.get_destinations("nonexistent")
+        assert result is None
+
+    def test_get_destinations_empty_by_default(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """New sessions have empty destinations."""
+        config_manager.add("test-session", sample_session_file)
+        result = config_manager.get_destinations("test-session")
+        assert result is not None
+        assert result.telegram == []
+        assert result.slack == []
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager add_destination tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerAddDestination:
+    """Tests for ConfigManager.add_destination()."""
+
+    def test_add_telegram_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """add_destination adds telegram destination to existing session."""
+        config_manager.add("test-session", sample_session_file)
+
+        result = config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123456789"),
+        )
+
+        assert result is True
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.telegram) == 1
+        assert destinations.telegram[0].chat_id == "123456789"
+
+    def test_add_slack_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """add_destination adds slack destination to existing session."""
+        config_manager.add("test-session", sample_session_file)
+
+        result = config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C0123456789"),
+        )
+
+        assert result is True
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.slack) == 1
+        assert destinations.slack[0].channel == "C0123456789"
+
+    def test_add_destination_creates_session_if_path_provided(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """add_destination creates session if it doesn't exist and path is provided."""
+        result = config_manager.add_destination(
+            "new-session",
+            TelegramDestination(chat_id="123"),
+            path=sample_session_file,
+        )
+
+        assert result is True
+        session = config_manager.get("new-session")
+        assert session is not None
+        assert session.path == sample_session_file
+
+    def test_add_destination_returns_false_if_no_session_and_no_path(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """add_destination returns False if session doesn't exist and no path."""
+        config_manager.load()
+        result = config_manager.add_destination(
+            "nonexistent",
+            TelegramDestination(chat_id="123"),
+        )
+        assert result is False
+
+    def test_add_destination_idempotent_telegram(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """Adding same telegram destination twice doesn't create duplicate."""
+        config_manager.add("test-session", sample_session_file)
+
+        # Add same destination twice
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.telegram) == 1
+
+    def test_add_destination_idempotent_slack(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """Adding same slack destination twice doesn't create duplicate."""
+        config_manager.add("test-session", sample_session_file)
+
+        # Add same destination twice
+        config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C123"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C123"),
+        )
+
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.slack) == 1
+
+    def test_add_destination_multiple_different(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """Can add multiple different destinations."""
+        config_manager.add("test-session", sample_session_file)
+
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="456"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C123"),
+        )
+
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.telegram) == 2
+        assert len(destinations.slack) == 1
+
+    def test_add_destination_validates_empty_telegram_chat_id(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """add_destination rejects empty telegram chat_id."""
+        config_manager.add("test-session", sample_session_file)
+
+        with pytest.raises(ValueError, match="chat_id must be non-empty"):
+            config_manager.add_destination(
+                "test-session",
+                TelegramDestination(chat_id=""),
+            )
+
+    def test_add_destination_validates_empty_slack_channel(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """add_destination rejects empty slack channel."""
+        config_manager.add("test-session", sample_session_file)
+
+        with pytest.raises(ValueError, match="channel must be non-empty"):
+            config_manager.add_destination(
+                "test-session",
+                SlackDestination(channel=""),
+            )
+
+    def test_add_destination_validates_path_absolute(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """add_destination rejects non-absolute path."""
+        config_manager.load()
+
+        with pytest.raises(ValueError, match="Path must be absolute"):
+            config_manager.add_destination(
+                "new-session",
+                TelegramDestination(chat_id="123"),
+                path=Path("relative/path.jsonl"),
+            )
+
+    def test_add_destination_validates_path_exists(
+        self,
+        config_manager: ConfigManager,
+        tmp_path: Path,
+    ) -> None:
+        """add_destination rejects non-existent path."""
+        config_manager.load()
+        non_existent = tmp_path / "does-not-exist.jsonl"
+
+        with pytest.raises(FileNotFoundError, match="Session file not found"):
+            config_manager.add_destination(
+                "new-session",
+                TelegramDestination(chat_id="123"),
+                path=non_existent,
+            )
+
+
+# ---------------------------------------------------------------------------
+# ConfigManager remove_destination tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigManagerRemoveDestination:
+    """Tests for ConfigManager.remove_destination()."""
+
+    def test_remove_telegram_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """remove_destination removes telegram destination."""
+        config_manager.add("test-session", sample_session_file)
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="456"),
+        )
+
+        result = config_manager.remove_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+
+        assert result is True
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.telegram) == 1
+        assert destinations.telegram[0].chat_id == "456"
+
+    def test_remove_slack_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """remove_destination removes slack destination."""
+        config_manager.add("test-session", sample_session_file)
+        config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C123"),
+        )
+        config_manager.add_destination(
+            "test-session",
+            SlackDestination(channel="C456"),
+        )
+
+        result = config_manager.remove_destination(
+            "test-session",
+            SlackDestination(channel="C123"),
+        )
+
+        assert result is True
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.slack) == 1
+        assert destinations.slack[0].channel == "C456"
+
+    def test_remove_destination_returns_false_for_nonexistent_session(
+        self,
+        config_manager: ConfigManager,
+    ) -> None:
+        """remove_destination returns False for non-existent session."""
+        config_manager.load()
+        result = config_manager.remove_destination(
+            "nonexistent",
+            TelegramDestination(chat_id="123"),
+        )
+        assert result is False
+
+    def test_remove_destination_returns_false_for_nonexistent_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """remove_destination returns False for non-existent destination."""
+        config_manager.add("test-session", sample_session_file)
+
+        result = config_manager.remove_destination(
+            "test-session",
+            TelegramDestination(chat_id="nonexistent"),
+        )
+        assert result is False
+
+    def test_remove_only_destination(
+        self,
+        config_manager: ConfigManager,
+        sample_session_file: Path,
+    ) -> None:
+        """remove_destination can remove the only destination."""
+        config_manager.add("test-session", sample_session_file)
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+
+        result = config_manager.remove_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+
+        assert result is True
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert destinations.telegram == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: Old format → New format migration
+# ---------------------------------------------------------------------------
+
+
+class TestConfigMigrationRoundtrip:
+    """Tests for migrating old format config and saving in new format."""
+
+    def test_load_old_save_new_roundtrip(
+        self,
+        config_manager: ConfigManager,
+        tmp_config_path: Path,
+    ) -> None:
+        """Loading old format and saving produces valid new format."""
+        old_yaml = """sessions:
+  - id: "session-001"
+    path: "/path/to/first.jsonl"
+  - id: "session-002"
+    path: "/path/to/second.jsonl"
+"""
+        tmp_config_path.write_text(old_yaml)
+
+        # Load old format
+        sessions = config_manager.load()
+        assert len(sessions) == 2
+
+        # Save (writes new format)
+        config_manager.save(sessions)
+
+        # Load again - should work with new format
+        sessions2 = config_manager.load()
+        assert len(sessions2) == 2
+        assert {s.session_id for s in sessions2} == {"session-001", "session-002"}
+
+        # Verify new format in file
+        content = tmp_config_path.read_text()
+        assert "session-001:" in content
+        assert "- id:" not in content
+
+    def test_add_destinations_after_migration(
+        self,
+        config_manager: ConfigManager,
+        tmp_config_path: Path,
+        sample_session_file: Path,
+    ) -> None:
+        """Can add destinations to migrated sessions."""
+        # Create old format with a real file path
+        old_yaml = f"""sessions:
+  - id: "test-session"
+    path: "{sample_session_file}"
+"""
+        tmp_config_path.write_text(old_yaml)
+
+        # Load (migrates in memory)
+        sessions = config_manager.load()
+        assert len(sessions) == 1
+        assert sessions[0].destinations.telegram == []
+
+        # Save to convert to new format
+        config_manager.save(sessions)
+
+        # Now add destinations
+        config_manager.add_destination(
+            "test-session",
+            TelegramDestination(chat_id="123"),
+        )
+
+        # Verify
+        destinations = config_manager.get_destinations("test-session")
+        assert destinations is not None
+        assert len(destinations.telegram) == 1


### PR DESCRIPTION
## Summary

- Add TelegramDestination and SlackDestination dataclasses for messaging destinations
- Add SessionDestinations to hold per-session destination lists  
- Add BotConfig for telegram/slack bot tokens
- Update ConfigManager to handle both old and new config formats
- Add automatic migration from old format (list) to new format (dict)
- Add add_destination/remove_destination methods (idempotent)
- Add get_bot_config/set_bot_config methods

## Test plan

- [x] Test loading old format config
- [x] Test loading new format config
- [x] Test migration behavior (in memory only)
- [x] Test adding/removing telegram destinations
- [x] Test adding/removing slack destinations
- [x] Test idempotent add (no duplicates)
- [x] Test empty destinations by default
- [x] All 884 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)