### PR TITLE
Issue #70: Add DestinationManager for attach/detach lifecycle

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -12,6 +12,7 @@ from claude_session_player.watcher.config import (
     TelegramDestination,
 )
 from claude_session_player.watcher.deps import check_slack_available, check_telegram_available
+from claude_session_player.watcher.destinations import AttachedDestination, DestinationManager
 from claude_session_player.watcher.event_buffer import EventBuffer, EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalReader
 from claude_session_player.watcher.service import WatcherService
@@ -20,10 +21,12 @@ from claude_session_player.watcher.state import SessionState, StateManager
 from claude_session_player.watcher.transformer import transform
 
 __all__ = [
+    "AttachedDestination",
     "BotConfig",
     "check_slack_available",
     "check_telegram_available",
     "ConfigManager",
+    "DestinationManager",
     "EventBuffer",
     "EventBufferManager",
     "FileWatcher",

--- a/issues/worklogs/70-worklog.md
+++ b/issues/worklogs/70-worklog.md
@@ -1,0 +1,99 @@
+# Issue #70: Add DestinationManager for attach/detach lifecycle
+
+## Summary
+
+Implemented `DestinationManager` class to manage the lifecycle of messaging destinations attached to sessions. The manager tracks which destinations are attached to which sessions, manages the keep-alive timer for file watching, and coordinates with `ConfigManager` for persistence.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/destinations.py`**
+   - `AttachedDestination` dataclass with fields: `type`, `identifier`, `attached_at`
+   - `DestinationManager` class implementing:
+     - `attach()`: Attach destination to session (starts file watching on first attach)
+     - `detach()`: Detach destination from session (starts keep-alive on last detach)
+     - `get_destinations()`: Get all destinations for a session
+     - `get_destinations_by_type()`: Get destinations filtered by type
+     - `has_destinations()`: Check if session has any destinations
+     - `restore_from_config()`: Restore state from persisted config on startup
+     - `shutdown()`: Cancel all keep-alive tasks on shutdown
+
+2. **`tests/watcher/test_destinations.py`**
+   - 28 tests covering all DestinationManager functionality
+
+### Modified Files
+
+1. **`claude_session_player/watcher/__init__.py`**
+   - Added exports for `AttachedDestination` and `DestinationManager`
+   - Updated `__all__` list
+
+## Design Decisions
+
+### Keep-Alive During Re-attach
+
+When a destination detaches and starts a keep-alive timer, then a new destination attaches before the timer expires, the implementation:
+- Cancels the keep-alive timer
+- Does NOT call `on_session_start` again (session is already being watched)
+- Adds the new destination to runtime state
+
+This is implemented by tracking whether a keep-alive task was running when processing an attach request.
+
+### Runtime State vs Persisted State
+
+- Runtime state (`_destinations` dict): Holds `AttachedDestination` objects with `attached_at` timestamps
+- Persisted state (via ConfigManager): Holds destination identifiers only (chat_id, channel)
+
+On `restore_from_config()`, runtime state is populated with current timestamps since original `attached_at` values aren't persisted.
+
+### Idempotent Operations
+
+- `attach()`: Returns `False` if destination already attached (no duplicate)
+- `detach()`: Returns `False` if destination not found (no error)
+
+Both operations remain idempotent as specified.
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestAttachedDestination | 2 | dataclass creation |
+| TestAttach | 8 | first attach, subsequent attach, idempotent, path from config, errors |
+| TestDetach | 4 | removes destination, not found, removes from config, starts keep-alive |
+| TestKeepAlive | 2 | expiry stops session, new attach cancels timer |
+| TestRestoreFromConfig | 3 | starts sessions, populates state, skips empty |
+| TestQueryMethods | 5 | get_destinations, get_destinations_by_type, has_destinations |
+| TestShutdown | 1 | cancels keep-alive tasks |
+| TestModuleImports | 3 | package imports and __all__ |
+
+## Test Results
+
+- **Before:** 884 tests
+- **After:** 912 tests (28 new)
+- All tests pass
+
+## Acceptance Criteria Status
+
+- [x] `DestinationManager` class implemented in `claude_session_player/watcher/destinations.py`
+- [x] `attach()` handles first-attach file watching start
+- [x] `attach()` is idempotent (duplicate attach returns False)
+- [x] `detach()` starts keep-alive timer on last destination removal
+- [x] Keep-alive timer (5 min default) delays file watching stop
+- [x] `restore_from_config()` restores state on service startup
+- [x] All state changes persisted to config
+- [x] Unit tests cover:
+  - [x] First attach starts session
+  - [x] Subsequent attaches are idempotent
+  - [x] Detach removes destination
+  - [x] Last detach starts keep-alive
+  - [x] Keep-alive expiry stops session
+  - [x] New attach during keep-alive cancels timer
+  - [x] Restore from config on startup
+- [x] Integration with WatcherService (tested via mocks)
+
+## Spec Reference
+
+Implements issue #70 from `.claude/specs/messaging-integration.md`:
+- DestinationManager component for attach/detach lifecycle
+- Keep-alive timer for file watching continuation after last detach
+- Coordination with ConfigManager for persistence

--- a/tests/watcher/test_destinations.py
+++ b/tests/watcher/test_destinations.py
@@ -1,0 +1,742 @@
+"""Tests for DestinationManager."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claude_session_player.watcher.config import (
+    ConfigManager,
+    SessionConfig,
+    SessionDestinations,
+    SlackDestination,
+    TelegramDestination,
+)
+from claude_session_player.watcher.destinations import (
+    AttachedDestination,
+    DestinationManager,
+)
+
+
+# ---------------------------------------------------------------------------
+# AttachedDestination tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttachedDestination:
+    """Tests for AttachedDestination dataclass."""
+
+    def test_create_telegram_destination(self) -> None:
+        """Can create telegram AttachedDestination."""
+        now = datetime.now()
+        dest = AttachedDestination(
+            type="telegram", identifier="123456789", attached_at=now
+        )
+        assert dest.type == "telegram"
+        assert dest.identifier == "123456789"
+        assert dest.attached_at == now
+
+    def test_create_slack_destination(self) -> None:
+        """Can create slack AttachedDestination."""
+        now = datetime.now()
+        dest = AttachedDestination(
+            type="slack", identifier="C0123456789", attached_at=now
+        )
+        assert dest.type == "slack"
+        assert dest.identifier == "C0123456789"
+        assert dest.attached_at == now
+
+
+# ---------------------------------------------------------------------------
+# DestinationManager fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_config_manager(tmp_path: Path) -> MagicMock:
+    """Create a mock ConfigManager."""
+    config = MagicMock(spec=ConfigManager)
+    config.get.return_value = None
+    config.load.return_value = []
+    config.add_destination.return_value = True
+    config.remove_destination.return_value = True
+    return config
+
+
+@pytest.fixture
+def on_session_start() -> AsyncMock:
+    """Create async mock for on_session_start callback."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def on_session_stop() -> AsyncMock:
+    """Create async mock for on_session_stop callback."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def destination_manager(
+    mock_config_manager: MagicMock,
+    on_session_start: AsyncMock,
+    on_session_stop: AsyncMock,
+) -> DestinationManager:
+    """Create a DestinationManager with mocks."""
+    return DestinationManager(
+        _config=mock_config_manager,
+        _on_session_start=on_session_start,
+        _on_session_stop=on_session_stop,
+        _keep_alive_seconds=1,  # Short timeout for tests
+    )
+
+
+@pytest.fixture
+def session_jsonl(tmp_path: Path) -> Path:
+    """Create a temporary JSONL session file."""
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text('{"type": "user"}\n')
+    return session_file
+
+
+# ---------------------------------------------------------------------------
+# Attach tests
+# ---------------------------------------------------------------------------
+
+
+class TestAttach:
+    """Tests for DestinationManager.attach()."""
+
+    @pytest.mark.asyncio
+    async def test_first_attach_starts_session(
+        self,
+        destination_manager: DestinationManager,
+        on_session_start: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """First attach to a session starts file watching."""
+        result = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert result is True
+        on_session_start.assert_called_once_with("test-session", session_jsonl)
+
+    @pytest.mark.asyncio
+    async def test_subsequent_attach_does_not_start_session(
+        self,
+        destination_manager: DestinationManager,
+        on_session_start: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Subsequent attach does not start file watching again."""
+        # First attach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Second attach (different destination)
+        result = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="slack",
+            identifier="C0123456789",
+        )
+
+        assert result is True
+        # on_session_start should only be called once (for first attach)
+        assert on_session_start.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_attach_is_idempotent(
+        self,
+        destination_manager: DestinationManager,
+        on_session_start: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Duplicate attach returns False without creating duplicate."""
+        # First attach
+        result1 = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Duplicate attach
+        result2 = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert result1 is True
+        assert result2 is False  # Idempotent - already attached
+
+        # Should only have one destination
+        destinations = destination_manager.get_destinations("test-session")
+        assert len(destinations) == 1
+
+    @pytest.mark.asyncio
+    async def test_attach_without_path_uses_config(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        on_session_start: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Attach without path uses path from config."""
+        # Setup config to return session
+        mock_config_manager.get.return_value = SessionConfig(
+            session_id="test-session",
+            path=session_jsonl,
+        )
+
+        result = await destination_manager.attach(
+            session_id="test-session",
+            path=None,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert result is True
+        on_session_start.assert_called_once_with("test-session", session_jsonl)
+
+    @pytest.mark.asyncio
+    async def test_attach_unknown_session_without_path_raises(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+    ) -> None:
+        """Attach to unknown session without path raises ValueError."""
+        mock_config_manager.get.return_value = None
+
+        with pytest.raises(ValueError, match="unknown and no path provided"):
+            await destination_manager.attach(
+                session_id="unknown-session",
+                path=None,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+    @pytest.mark.asyncio
+    async def test_attach_invalid_destination_type_raises(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Attach with invalid destination_type raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid destination_type"):
+            await destination_manager.attach(
+                session_id="test-session",
+                path=session_jsonl,
+                destination_type="invalid",
+                identifier="123456789",
+            )
+
+    @pytest.mark.asyncio
+    async def test_attach_persists_to_config(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Attach persists destination to config."""
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Verify config was updated
+        mock_config_manager.add_destination.assert_called_once()
+        call_args = mock_config_manager.add_destination.call_args
+        assert call_args[0][0] == "test-session"
+        assert isinstance(call_args[0][1], TelegramDestination)
+        assert call_args[0][1].chat_id == "123456789"
+
+    @pytest.mark.asyncio
+    async def test_attach_slack_destination(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Attach slack destination persists correctly."""
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="slack",
+            identifier="C0123456789",
+        )
+
+        call_args = mock_config_manager.add_destination.call_args
+        assert isinstance(call_args[0][1], SlackDestination)
+        assert call_args[0][1].channel == "C0123456789"
+
+
+# ---------------------------------------------------------------------------
+# Detach tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetach:
+    """Tests for DestinationManager.detach()."""
+
+    @pytest.mark.asyncio
+    async def test_detach_removes_destination(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Detach removes destination from runtime state."""
+        # First attach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Detach
+        result = await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert result is True
+        destinations = destination_manager.get_destinations("test-session")
+        assert len(destinations) == 0
+
+    @pytest.mark.asyncio
+    async def test_detach_not_found_returns_false(
+        self,
+        destination_manager: DestinationManager,
+    ) -> None:
+        """Detach returns False if destination not found."""
+        result = await destination_manager.detach(
+            session_id="unknown-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_detach_removes_from_config(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Detach removes destination from config."""
+        # First attach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Detach
+        await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        mock_config_manager.remove_destination.assert_called_once()
+        call_args = mock_config_manager.remove_destination.call_args
+        assert call_args[0][0] == "test-session"
+        assert isinstance(call_args[0][1], TelegramDestination)
+        assert call_args[0][1].chat_id == "123456789"
+
+    @pytest.mark.asyncio
+    async def test_last_detach_starts_keep_alive(
+        self,
+        destination_manager: DestinationManager,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Last detach starts keep-alive timer."""
+        # Attach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Detach
+        await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # on_session_stop should NOT be called immediately
+        on_session_stop.assert_not_called()
+
+        # Wait for keep-alive to expire (1 second in tests)
+        await asyncio.sleep(1.5)
+
+        # Now on_session_stop should have been called
+        on_session_stop.assert_called_once_with("test-session")
+
+
+# ---------------------------------------------------------------------------
+# Keep-alive tests
+# ---------------------------------------------------------------------------
+
+
+class TestKeepAlive:
+    """Tests for keep-alive timer behavior."""
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_expiry_stops_session(
+        self,
+        destination_manager: DestinationManager,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Keep-alive expiry stops file watching."""
+        # Attach and detach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+        await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Wait for keep-alive to expire
+        await asyncio.sleep(1.5)
+
+        on_session_stop.assert_called_once_with("test-session")
+
+    @pytest.mark.asyncio
+    async def test_new_attach_during_keep_alive_cancels_timer(
+        self,
+        destination_manager: DestinationManager,
+        on_session_start: AsyncMock,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """New attach during keep-alive cancels timer."""
+        # Attach and detach
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+        await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Immediately re-attach before keep-alive expires
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="slack",
+            identifier="C0123456789",
+        )
+
+        # Wait for what would have been keep-alive expiry
+        await asyncio.sleep(1.5)
+
+        # on_session_stop should NOT have been called
+        on_session_stop.assert_not_called()
+
+        # on_session_start should only be called once (first attach)
+        assert on_session_start.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Restore from config tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreFromConfig:
+    """Tests for restore_from_config()."""
+
+    @pytest.mark.asyncio
+    async def test_restore_from_config_starts_sessions(
+        self,
+        mock_config_manager: MagicMock,
+        on_session_start: AsyncMock,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """restore_from_config starts file watching for sessions with destinations."""
+        # Setup config to return sessions with destinations
+        mock_config_manager.load.return_value = [
+            SessionConfig(
+                session_id="session-1",
+                path=session_jsonl,
+                destinations=SessionDestinations(
+                    telegram=[TelegramDestination(chat_id="123456789")],
+                    slack=[],
+                ),
+            ),
+            SessionConfig(
+                session_id="session-2",
+                path=session_jsonl,
+                destinations=SessionDestinations(
+                    telegram=[],
+                    slack=[SlackDestination(channel="C0123456789")],
+                ),
+            ),
+        ]
+
+        manager = DestinationManager(
+            _config=mock_config_manager,
+            _on_session_start=on_session_start,
+            _on_session_stop=on_session_stop,
+        )
+
+        await manager.restore_from_config()
+
+        # Both sessions should have started
+        assert on_session_start.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_restore_from_config_populates_runtime_state(
+        self,
+        mock_config_manager: MagicMock,
+        on_session_start: AsyncMock,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """restore_from_config populates runtime state."""
+        mock_config_manager.load.return_value = [
+            SessionConfig(
+                session_id="session-1",
+                path=session_jsonl,
+                destinations=SessionDestinations(
+                    telegram=[TelegramDestination(chat_id="123")],
+                    slack=[SlackDestination(channel="C456")],
+                ),
+            ),
+        ]
+
+        manager = DestinationManager(
+            _config=mock_config_manager,
+            _on_session_start=on_session_start,
+            _on_session_stop=on_session_stop,
+        )
+
+        await manager.restore_from_config()
+
+        destinations = manager.get_destinations("session-1")
+        assert len(destinations) == 2
+        assert any(d.type == "telegram" and d.identifier == "123" for d in destinations)
+        assert any(d.type == "slack" and d.identifier == "C456" for d in destinations)
+
+    @pytest.mark.asyncio
+    async def test_restore_from_config_skips_empty_destinations(
+        self,
+        mock_config_manager: MagicMock,
+        on_session_start: AsyncMock,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """restore_from_config skips sessions with no destinations."""
+        mock_config_manager.load.return_value = [
+            SessionConfig(
+                session_id="session-1",
+                path=session_jsonl,
+                destinations=SessionDestinations(telegram=[], slack=[]),
+            ),
+        ]
+
+        manager = DestinationManager(
+            _config=mock_config_manager,
+            _on_session_start=on_session_start,
+            _on_session_stop=on_session_stop,
+        )
+
+        await manager.restore_from_config()
+
+        # No sessions should have started (empty destinations)
+        on_session_start.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Query tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryMethods:
+    """Tests for get_destinations and has_destinations."""
+
+    @pytest.mark.asyncio
+    async def test_get_destinations_empty(
+        self,
+        destination_manager: DestinationManager,
+    ) -> None:
+        """get_destinations returns empty list for unknown session."""
+        destinations = destination_manager.get_destinations("unknown-session")
+        assert destinations == []
+
+    @pytest.mark.asyncio
+    async def test_get_destinations_returns_copy(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """get_destinations returns a copy of the list."""
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        destinations1 = destination_manager.get_destinations("test-session")
+        destinations2 = destination_manager.get_destinations("test-session")
+
+        # Should be equal but not the same object
+        assert destinations1 == destinations2
+        assert destinations1 is not destinations2
+
+    @pytest.mark.asyncio
+    async def test_get_destinations_by_type(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """get_destinations_by_type filters by type."""
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="slack",
+            identifier="C0123456789",
+        )
+
+        telegram_dests = destination_manager.get_destinations_by_type(
+            "test-session", "telegram"
+        )
+        slack_dests = destination_manager.get_destinations_by_type(
+            "test-session", "slack"
+        )
+
+        assert len(telegram_dests) == 1
+        assert telegram_dests[0].type == "telegram"
+        assert len(slack_dests) == 1
+        assert slack_dests[0].type == "slack"
+
+    @pytest.mark.asyncio
+    async def test_has_destinations_true(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """has_destinations returns True when destinations exist."""
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        assert destination_manager.has_destinations("test-session") is True
+
+    @pytest.mark.asyncio
+    async def test_has_destinations_false(
+        self,
+        destination_manager: DestinationManager,
+    ) -> None:
+        """has_destinations returns False when no destinations."""
+        assert destination_manager.has_destinations("unknown-session") is False
+
+
+# ---------------------------------------------------------------------------
+# Shutdown tests
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    """Tests for shutdown behavior."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_keep_alive_tasks(
+        self,
+        destination_manager: DestinationManager,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """shutdown cancels all keep-alive tasks."""
+        # Attach and detach to start keep-alive
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier="123456789",
+        )
+        await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="123456789",
+        )
+
+        # Shutdown immediately
+        await destination_manager.shutdown()
+
+        # Wait to ensure keep-alive would have expired
+        await asyncio.sleep(1.5)
+
+        # on_session_stop should NOT have been called (task was cancelled)
+        on_session_stop.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Module imports tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    """Tests for module imports and __all__."""
+
+    def test_import_from_watcher(self) -> None:
+        """Can import DestinationManager from watcher package."""
+        from claude_session_player.watcher import DestinationManager as DM
+
+        assert DM is DestinationManager
+
+    def test_import_attached_destination_from_watcher(self) -> None:
+        """Can import AttachedDestination from watcher package."""
+        from claude_session_player.watcher import AttachedDestination as AD
+
+        assert AD is AttachedDestination
+
+    def test_in_all(self) -> None:
+        """DestinationManager and AttachedDestination are in __all__."""
+        from claude_session_player import watcher
+
+        assert "DestinationManager" in watcher.__all__
+        assert "AttachedDestination" in watcher.__all__


### PR DESCRIPTION
## Summary

- Add `DestinationManager` class to manage messaging destination lifecycle
- Implement attach/detach with keep-alive timer for file watching
- Add 28 unit tests for full coverage

## Changes

- **New:** `claude_session_player/watcher/destinations.py` - DestinationManager implementation
- **New:** `tests/watcher/test_destinations.py` - 28 unit tests
- **Modified:** `claude_session_player/watcher/__init__.py` - Export new classes
- **New:** `issues/worklogs/70-worklog.md` - Implementation worklog

## Test plan

- [x] First attach starts file watching
- [x] Subsequent attaches are idempotent
- [x] Detach removes destination
- [x] Last detach starts keep-alive timer
- [x] Keep-alive expiry stops file watching
- [x] New attach during keep-alive cancels timer
- [x] Restore from config on startup
- [x] All 912 tests pass

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)