### PR TITLE
Issue #71: Add TelegramPublisher for Telegram Bot API integration

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -18,6 +18,18 @@ from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalR
 from claude_session_player.watcher.service import WatcherService
 from claude_session_player.watcher.sse import SSEConnection, SSEManager
 from claude_session_player.watcher.state import SessionState, StateManager
+from claude_session_player.watcher.telegram_publisher import (
+    TelegramAuthError,
+    TelegramError,
+    TelegramPublisher,
+    ToolCallInfo,
+    escape_markdown,
+    format_context_compacted,
+    format_system_message,
+    format_turn_message,
+    format_user_message,
+    get_tool_icon,
+)
 from claude_session_player.watcher.transformer import transform
 
 __all__ = [
@@ -27,9 +39,15 @@ __all__ = [
     "check_telegram_available",
     "ConfigManager",
     "DestinationManager",
+    "escape_markdown",
     "EventBuffer",
     "EventBufferManager",
     "FileWatcher",
+    "format_context_compacted",
+    "format_system_message",
+    "format_turn_message",
+    "format_user_message",
+    "get_tool_icon",
     "IncrementalReader",
     "SessionConfig",
     "SessionDestinations",
@@ -38,7 +56,11 @@ __all__ = [
     "SSEConnection",
     "SSEManager",
     "StateManager",
+    "TelegramAuthError",
     "TelegramDestination",
+    "TelegramError",
+    "TelegramPublisher",
+    "ToolCallInfo",
     "WatcherAPI",
     "WatcherService",
     "transform",

--- a/claude_session_player/watcher/telegram_publisher.py
+++ b/claude_session_player/watcher/telegram_publisher.py
@@ -1,0 +1,347 @@
+"""Telegram message publisher using aiogram library."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+
+from claude_session_player.watcher.deps import check_telegram_available
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Custom Exceptions
+# ---------------------------------------------------------------------------
+
+
+class TelegramError(Exception):
+    """Base exception for Telegram operations."""
+
+    pass
+
+
+class TelegramAuthError(TelegramError):
+    """Bot authentication/validation failed."""
+
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Message Formatting Utilities
+# ---------------------------------------------------------------------------
+
+
+# Characters that need escaping in Telegram Markdown V1
+# Reference: https://core.telegram.org/bots/api#markdown-style
+_MARKDOWN_ESCAPE_CHARS = re.compile(r"([_*`\[])")
+
+
+def escape_markdown(text: str) -> str:
+    """Escape special characters for Telegram Markdown.
+
+    Escapes: _ * ` [
+
+    Args:
+        text: Raw text to escape.
+
+    Returns:
+        Text with special characters escaped.
+    """
+    return _MARKDOWN_ESCAPE_CHARS.sub(r"\\\1", text)
+
+
+@dataclass
+class ToolCallInfo:
+    """Information about a tool call for formatting."""
+
+    name: str
+    label: str
+    icon: str
+    result: str | None = None
+    is_error: bool = False
+
+
+# Tool name to icon mapping
+_TOOL_ICONS = {
+    "Read": "📖",
+    "Write": "📝",
+    "Edit": "✏️",
+    "Bash": "🔧",
+    "Glob": "🔍",
+    "Grep": "🔍",
+    "Task": "🤖",
+    "WebSearch": "🌐",
+    "WebFetch": "🌐",
+}
+
+
+def get_tool_icon(tool_name: str) -> str:
+    """Get the icon for a tool name.
+
+    Args:
+        tool_name: Name of the tool.
+
+    Returns:
+        Emoji icon for the tool.
+    """
+    return _TOOL_ICONS.get(tool_name, "⚙️")
+
+
+def format_user_message(text: str) -> str:
+    """Format a user message for Telegram.
+
+    Args:
+        text: User message text.
+
+    Returns:
+        Formatted Telegram Markdown message.
+    """
+    escaped = escape_markdown(text)
+    return f"👤 *User*\n\n{escaped}"
+
+
+def format_turn_message(
+    assistant_text: str | None,
+    tool_calls: list[ToolCallInfo],
+    duration_ms: int | None,
+) -> str:
+    """Format a complete turn message for Telegram.
+
+    Args:
+        assistant_text: Optional assistant response text.
+        tool_calls: List of tool call information.
+        duration_ms: Optional turn duration in milliseconds.
+
+    Returns:
+        Formatted Telegram Markdown message.
+    """
+    parts = ["🤖 *Assistant*"]
+
+    if assistant_text:
+        parts.append(f"\n\n{escape_markdown(assistant_text)}")
+
+    for tool in tool_calls:
+        parts.append("\n\n───────────────")
+        parts.append(f"\n{tool.icon} *{escape_markdown(tool.name)}* `{escape_markdown(tool.label)}`")
+        if tool.result:
+            # Truncate long results
+            result = tool.result[:500]
+            if len(tool.result) > 500:
+                result += "..."
+            result = escape_markdown(result)
+            parts.append(f"\n✓ {result}")
+        elif tool.is_error:
+            parts.append("\n✗ Error")
+
+    if duration_ms:
+        seconds = duration_ms / 1000
+        parts.append(f"\n\n_⏱ {seconds:.1f}s_")
+
+    return "".join(parts)
+
+
+def format_system_message(text: str) -> str:
+    """Format a system message for Telegram.
+
+    Args:
+        text: System message text.
+
+    Returns:
+        Formatted Telegram Markdown message.
+    """
+    return f"⚡ *{escape_markdown(text)}*"
+
+
+def format_context_compacted() -> str:
+    """Format context compaction notice for Telegram.
+
+    Returns:
+        Formatted Telegram Markdown message.
+    """
+    return "⚡ *Context compacted* — previous messages cleared"
+
+
+# ---------------------------------------------------------------------------
+# TelegramPublisher
+# ---------------------------------------------------------------------------
+
+
+# Maximum message length for Telegram
+_MAX_MESSAGE_LENGTH = 4096
+
+
+def _truncate_message(text: str, max_length: int = _MAX_MESSAGE_LENGTH) -> str:
+    """Truncate message to fit Telegram's character limit.
+
+    Args:
+        text: Message text to truncate.
+        max_length: Maximum length (default 4096).
+
+    Returns:
+        Truncated message with indicator if needed.
+    """
+    if len(text) <= max_length:
+        return text
+    # Leave room for truncation indicator
+    return text[: max_length - 20] + "\n\n... [truncated]"
+
+
+class TelegramPublisher:
+    """Publisher for sending messages via Telegram Bot API.
+
+    Uses aiogram library for async Telegram API communication.
+    Handles validation, sending, editing, and retrying messages.
+    """
+
+    def __init__(self, token: str | None = None) -> None:
+        """Initialize the publisher.
+
+        Args:
+            token: Telegram bot token from BotFather.
+        """
+        self._token = token
+        self._bot: object | None = None  # aiogram.Bot when available
+        self._validated = False
+
+    async def validate(self) -> None:
+        """Validate bot credentials by calling getMe.
+
+        Raises:
+            ValueError: If token not configured.
+            TelegramAuthError: If token invalid or bot unauthorized.
+            TelegramError: If aiogram is not installed.
+        """
+        if not self._token:
+            raise ValueError("Telegram bot token not configured")
+
+        if self._validated:
+            return
+
+        if not check_telegram_available():
+            raise TelegramError(
+                "aiogram library not installed. Install with: pip install aiogram"
+            )
+
+        try:
+            from aiogram import Bot
+            from aiogram.exceptions import TelegramAPIError
+
+            self._bot = Bot(token=self._token)
+            me = await self._bot.get_me()
+            logger.info(f"Telegram bot validated: @{me.username}")
+            self._validated = True
+        except TelegramAPIError as e:
+            raise TelegramAuthError(f"Bot validation failed: {e}") from e
+
+    async def send_message(
+        self,
+        chat_id: str,
+        text: str,
+        parse_mode: str = "Markdown",
+    ) -> int:
+        """Send a new message to a chat.
+
+        Args:
+            chat_id: Telegram chat ID.
+            text: Message text (Markdown formatted).
+            parse_mode: Telegram parse mode (default "Markdown").
+
+        Returns:
+            message_id of the sent message.
+
+        Raises:
+            TelegramError: On API failure after retry.
+        """
+        if not self._validated:
+            await self.validate()
+
+        # Truncate if needed
+        text = _truncate_message(text)
+
+        from aiogram.exceptions import TelegramAPIError
+
+        try:
+            result = await self._bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                parse_mode=parse_mode,
+            )
+            return result.message_id
+        except TelegramAPIError:
+            # Retry once after a short delay
+            await asyncio.sleep(1)
+            try:
+                result = await self._bot.send_message(
+                    chat_id=chat_id,
+                    text=text,
+                    parse_mode=parse_mode,
+                )
+                return result.message_id
+            except TelegramAPIError as e2:
+                logger.warning(f"Failed to send Telegram message to {chat_id}: {e2}")
+                raise TelegramError(f"Send failed: {e2}") from e2
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: int,
+        text: str,
+        parse_mode: str = "Markdown",
+    ) -> bool:
+        """Edit an existing message.
+
+        Args:
+            chat_id: Telegram chat ID.
+            message_id: ID of the message to edit.
+            text: New message text (Markdown formatted).
+            parse_mode: Telegram parse mode (default "Markdown").
+
+        Returns:
+            True if edited successfully, False if message not found/editable.
+        """
+        if not self._validated:
+            await self.validate()
+
+        # Truncate if needed
+        text = _truncate_message(text)
+
+        from aiogram.exceptions import TelegramAPIError
+
+        try:
+            await self._bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text=text,
+                parse_mode=parse_mode,
+            )
+            return True
+        except TelegramAPIError as e:
+            error_str = str(e).lower()
+            if "message is not modified" in error_str:
+                return True  # Content unchanged, that's fine
+            if "message to edit not found" in error_str:
+                return False  # Message deleted or too old
+
+            # Retry once for other errors
+            await asyncio.sleep(1)
+            try:
+                await self._bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=text,
+                    parse_mode=parse_mode,
+                )
+                return True
+            except TelegramAPIError as e2:
+                logger.warning(f"Failed to edit Telegram message {message_id}: {e2}")
+                return False
+
+    async def close(self) -> None:
+        """Close the bot session."""
+        if self._bot is not None:
+            await self._bot.session.close()
+            self._bot = None
+            self._validated = False

--- a/issues/worklogs/71-worklog.md
+++ b/issues/worklogs/71-worklog.md
@@ -1,0 +1,122 @@
+# Issue #71: Add TelegramPublisher for Telegram Bot API integration
+
+## Summary
+
+Implemented `TelegramPublisher` class for sending and updating messages via the Telegram Bot API using the aiogram library. This includes custom exceptions, message formatting utilities, and graceful handling when aiogram is not installed.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/telegram_publisher.py`**
+   - `TelegramError`: Base exception for Telegram operations
+   - `TelegramAuthError`: Bot authentication/validation failed exception
+   - `ToolCallInfo`: Dataclass for tool call information in message formatting
+   - `escape_markdown()`: Escapes special characters for Telegram Markdown
+   - `get_tool_icon()`: Returns emoji icon for tool names
+   - `format_user_message()`: Formats user messages for Telegram
+   - `format_turn_message()`: Formats complete turn messages (assistant + tools + duration)
+   - `format_system_message()`: Formats system messages
+   - `format_context_compacted()`: Returns context compaction notice
+   - `_truncate_message()`: Truncates messages to 4096 char limit
+   - `TelegramPublisher` class with:
+     - `__init__(token)`: Initialize with optional bot token
+     - `validate()`: Validate bot credentials via `get_me()`
+     - `send_message()`: Send new message with retry and truncation
+     - `edit_message()`: Edit existing message with retry and "not modified" handling
+     - `close()`: Close bot session
+
+2. **`tests/watcher/test_telegram_publisher.py`**
+   - 55 tests covering all functionality
+   - Uses `make_telegram_api_error()` helper for creating aiogram exceptions
+
+### Modified Files
+
+1. **`claude_session_player/watcher/__init__.py`**
+   - Added exports for all new classes and functions
+   - Updated `__all__` list with 10 new exports
+
+## Design Decisions
+
+### Markdown Escaping Strategy
+
+Using Telegram Markdown V1 style escaping which requires escaping: `_`, `*`, `` ` ``, `[`. The `escape_markdown()` function uses a compiled regex for efficiency.
+
+### Error Handling
+
+- `TelegramError` is the base exception for all Telegram operations
+- `TelegramAuthError` specifically indicates authentication failures
+- Both `send_message()` and `edit_message()` retry once on API failure before giving up
+- `edit_message()` returns `True` for "message is not modified" errors (content unchanged is fine)
+- `edit_message()` returns `False` for "message to edit not found" errors
+
+### Message Truncation
+
+Messages are truncated to 4076 characters (4096 - 20 for truncation indicator) to fit Telegram's message length limit. The truncation indicator `\n\n... [truncated]` is appended.
+
+### Graceful Dependency Handling
+
+If aiogram is not installed, `validate()` raises `TelegramError` with a helpful message. This is checked using `check_telegram_available()` from `deps.py`.
+
+### Tool Icons
+
+Added emoji icons for common tools:
+- Read: 📖
+- Write: 📝
+- Edit: ✏️
+- Bash: 🔧
+- Glob/Grep: 🔍
+- Task: 🤖
+- WebSearch/WebFetch: 🌐
+- Unknown: ⚙️
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestEscapeMarkdown | 7 | markdown escaping |
+| TestGetToolIcon | 6 | tool icon mapping |
+| TestFormatUserMessage | 3 | user message formatting |
+| TestFormatTurnMessage | 7 | turn message formatting |
+| TestFormatSystemMessage | 2 | system message formatting |
+| TestFormatContextCompacted | 1 | compaction notice |
+| TestTruncateMessage | 4 | message truncation |
+| TestTelegramPublisherInit | 2 | initialization |
+| TestTelegramPublisherValidate | 5 | validation |
+| TestTelegramPublisherSendMessage | 5 | send message |
+| TestTelegramPublisherEditMessage | 6 | edit message |
+| TestTelegramPublisherClose | 2 | close session |
+| TestModuleImports | 5 | package imports |
+
+## Test Results
+
+- **Before:** 912 tests
+- **After:** 967 tests (55 new)
+- All tests pass
+
+## Acceptance Criteria Status
+
+- [x] `TelegramPublisher` class in `claude_session_player/watcher/telegram_publisher.py`
+- [x] `validate()` checks token and calls `get_me()`
+- [x] `send_message()` sends with retry, respects 4096 char limit
+- [x] `edit_message()` edits with retry, handles "not modified" gracefully
+- [x] Custom exceptions: `TelegramError`, `TelegramAuthError`
+- [x] Formatting utilities for user/turn/system messages
+- [x] Markdown escaping for user content
+- [x] `close()` properly shuts down bot session
+- [x] Unit tests with mocked aiogram:
+  - [x] Validation success/failure
+  - [x] Send message success
+  - [x] Send message with retry
+  - [x] Send message truncation
+  - [x] Edit message success
+  - [x] Edit message "not modified" handling
+  - [x] Message formatting
+- [x] Graceful handling when aiogram not installed
+
+## Spec Reference
+
+Implements issue #71 from `.claude/specs/messaging-integration.md`:
+- TelegramPublisher component for Telegram Bot API integration
+- Message sending and editing with retry logic
+- Message formatting utilities for Telegram Markdown

--- a/tests/watcher/test_telegram_publisher.py
+++ b/tests/watcher/test_telegram_publisher.py
@@ -1,0 +1,724 @@
+"""Tests for TelegramPublisher."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.exceptions import TelegramAPIError
+from aiogram.methods import GetMe, SendMessage, EditMessageText
+
+from claude_session_player.watcher.telegram_publisher import (
+    TelegramAuthError,
+    TelegramError,
+    TelegramPublisher,
+    ToolCallInfo,
+    _truncate_message,
+    escape_markdown,
+    format_context_compacted,
+    format_system_message,
+    format_turn_message,
+    format_user_message,
+    get_tool_icon,
+)
+
+
+def make_telegram_api_error(message: str, method_type: str = "send") -> TelegramAPIError:
+    """Create a TelegramAPIError for testing.
+
+    Args:
+        message: Error message.
+        method_type: Type of method ("get_me", "send", "edit").
+
+    Returns:
+        TelegramAPIError instance.
+    """
+    if method_type == "get_me":
+        method = GetMe()
+    elif method_type == "edit":
+        method = EditMessageText(chat_id=0, message_id=0, text="")
+    else:
+        method = SendMessage(chat_id=0, text="")
+    return TelegramAPIError(method=method, message=message)
+
+
+# ---------------------------------------------------------------------------
+# Markdown escaping tests
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeMarkdown:
+    """Tests for escape_markdown function."""
+
+    def test_escapes_underscore(self) -> None:
+        """Underscores are escaped."""
+        assert escape_markdown("hello_world") == r"hello\_world"
+
+    def test_escapes_asterisk(self) -> None:
+        """Asterisks are escaped."""
+        assert escape_markdown("hello*world") == r"hello\*world"
+
+    def test_escapes_backtick(self) -> None:
+        """Backticks are escaped."""
+        assert escape_markdown("hello`world") == r"hello\`world"
+
+    def test_escapes_bracket(self) -> None:
+        """Square brackets are escaped."""
+        assert escape_markdown("hello[world]") == r"hello\[world]"
+
+    def test_escapes_multiple_chars(self) -> None:
+        """Multiple special chars are escaped."""
+        assert escape_markdown("_*`[") == r"\_\*\`\["
+
+    def test_preserves_normal_text(self) -> None:
+        """Normal text is preserved."""
+        assert escape_markdown("hello world") == "hello world"
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty."""
+        assert escape_markdown("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Tool icon tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetToolIcon:
+    """Tests for get_tool_icon function."""
+
+    def test_read_icon(self) -> None:
+        """Read tool has book icon."""
+        assert get_tool_icon("Read") == "\U0001f4d6"
+
+    def test_write_icon(self) -> None:
+        """Write tool has memo icon."""
+        assert get_tool_icon("Write") == "\U0001f4dd"
+
+    def test_edit_icon(self) -> None:
+        """Edit tool has pencil icon."""
+        assert get_tool_icon("Edit") == "\u270f\ufe0f"
+
+    def test_bash_icon(self) -> None:
+        """Bash tool has wrench icon."""
+        assert get_tool_icon("Bash") == "\U0001f527"
+
+    def test_task_icon(self) -> None:
+        """Task tool has robot icon."""
+        assert get_tool_icon("Task") == "\U0001f916"
+
+    def test_unknown_tool_icon(self) -> None:
+        """Unknown tool gets gear icon."""
+        assert get_tool_icon("UnknownTool") == "\u2699\ufe0f"
+
+
+# ---------------------------------------------------------------------------
+# Message formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatUserMessage:
+    """Tests for format_user_message function."""
+
+    def test_basic_message(self) -> None:
+        """Formats basic user message."""
+        result = format_user_message("Hello world")
+        assert result == "\U0001f464 *User*\n\nHello world"
+
+    def test_escapes_markdown(self) -> None:
+        """Escapes markdown in user text."""
+        result = format_user_message("Hello *world*")
+        assert r"\*world\*" in result
+
+    def test_multiline_message(self) -> None:
+        """Handles multiline message."""
+        result = format_user_message("Line 1\nLine 2")
+        assert "Line 1\nLine 2" in result
+
+
+class TestFormatTurnMessage:
+    """Tests for format_turn_message function."""
+
+    def test_assistant_text_only(self) -> None:
+        """Formats turn with assistant text only."""
+        result = format_turn_message(
+            assistant_text="Hello world",
+            tool_calls=[],
+            duration_ms=None,
+        )
+        assert "\U0001f916 *Assistant*" in result
+        assert "Hello world" in result
+
+    def test_with_duration(self) -> None:
+        """Includes duration footer."""
+        result = format_turn_message(
+            assistant_text="Hello",
+            tool_calls=[],
+            duration_ms=5000,
+        )
+        assert "5.0s" in result
+        assert "\u23f1" in result  # Timer emoji
+
+    def test_with_tool_call(self) -> None:
+        """Formats tool call."""
+        result = format_turn_message(
+            assistant_text=None,
+            tool_calls=[
+                ToolCallInfo(
+                    name="Read",
+                    label="file.txt",
+                    icon="\U0001f4d6",
+                    result="contents",
+                    is_error=False,
+                )
+            ],
+            duration_ms=None,
+        )
+        assert "*Read*" in result
+        assert "`file.txt`" in result
+        assert "\u2713 contents" in result
+
+    def test_tool_call_with_error(self) -> None:
+        """Formats tool call error."""
+        result = format_turn_message(
+            assistant_text=None,
+            tool_calls=[
+                ToolCallInfo(
+                    name="Bash",
+                    label="ls -la",
+                    icon="\U0001f527",
+                    result=None,
+                    is_error=True,
+                )
+            ],
+            duration_ms=None,
+        )
+        assert "\u2717 Error" in result
+
+    def test_multiple_tool_calls(self) -> None:
+        """Handles multiple tool calls."""
+        result = format_turn_message(
+            assistant_text=None,
+            tool_calls=[
+                ToolCallInfo(
+                    name="Read", label="a.txt", icon="\U0001f4d6", result="a", is_error=False
+                ),
+                ToolCallInfo(
+                    name="Read", label="b.txt", icon="\U0001f4d6", result="b", is_error=False
+                ),
+            ],
+            duration_ms=None,
+        )
+        assert "a.txt" in result
+        assert "b.txt" in result
+        # Dividers between tools
+        assert result.count("\u2500\u2500\u2500") >= 2
+
+    def test_truncates_long_tool_result(self) -> None:
+        """Truncates long tool results."""
+        long_result = "x" * 600
+        result = format_turn_message(
+            assistant_text=None,
+            tool_calls=[
+                ToolCallInfo(
+                    name="Read",
+                    label="big.txt",
+                    icon="\U0001f4d6",
+                    result=long_result,
+                    is_error=False,
+                )
+            ],
+            duration_ms=None,
+        )
+        assert "..." in result
+        # Should be truncated to 500 chars
+        assert len(result) < len(long_result) + 200
+
+    def test_escapes_assistant_text(self) -> None:
+        """Escapes markdown in assistant text."""
+        result = format_turn_message(
+            assistant_text="Hello _world_",
+            tool_calls=[],
+            duration_ms=None,
+        )
+        assert r"\_world\_" in result
+
+
+class TestFormatSystemMessage:
+    """Tests for format_system_message function."""
+
+    def test_basic_system_message(self) -> None:
+        """Formats system message."""
+        result = format_system_message("Session started")
+        assert result == "\u26a1 *Session started*"
+
+    def test_escapes_markdown(self) -> None:
+        """Escapes markdown in system text."""
+        result = format_system_message("Error: _failed_")
+        assert r"\_failed\_" in result
+
+
+class TestFormatContextCompacted:
+    """Tests for format_context_compacted function."""
+
+    def test_compaction_message(self) -> None:
+        """Returns context compacted message."""
+        result = format_context_compacted()
+        assert result == "\u26a1 *Context compacted* \u2014 previous messages cleared"
+
+
+# ---------------------------------------------------------------------------
+# Message truncation tests
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateMessage:
+    """Tests for _truncate_message function."""
+
+    def test_short_message_unchanged(self) -> None:
+        """Short messages are not truncated."""
+        text = "Hello world"
+        result = _truncate_message(text)
+        assert result == text
+
+    def test_truncates_long_message(self) -> None:
+        """Long messages are truncated."""
+        text = "x" * 5000
+        result = _truncate_message(text)
+        assert len(result) <= 4096
+        assert result.endswith("... [truncated]")
+
+    def test_exact_limit_unchanged(self) -> None:
+        """Message at exact limit is not truncated."""
+        text = "x" * 4096
+        result = _truncate_message(text)
+        assert result == text
+
+    def test_custom_max_length(self) -> None:
+        """Custom max_length is respected."""
+        text = "x" * 100
+        result = _truncate_message(text, max_length=50)
+        assert len(result) <= 50
+        assert result.endswith("... [truncated]")
+
+
+# ---------------------------------------------------------------------------
+# TelegramPublisher tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramPublisherInit:
+    """Tests for TelegramPublisher initialization."""
+
+    def test_init_with_token(self) -> None:
+        """Initializes with token."""
+        publisher = TelegramPublisher(token="test-token")
+        assert publisher._token == "test-token"
+        assert publisher._validated is False
+        assert publisher._bot is None
+
+    def test_init_without_token(self) -> None:
+        """Initializes without token."""
+        publisher = TelegramPublisher()
+        assert publisher._token is None
+        assert publisher._validated is False
+
+
+class TestTelegramPublisherValidate:
+    """Tests for TelegramPublisher.validate()."""
+
+    @pytest.mark.asyncio
+    async def test_validate_without_token_raises(self) -> None:
+        """Validation fails without token."""
+        publisher = TelegramPublisher(token=None)
+        with pytest.raises(ValueError, match="token not configured"):
+            await publisher.validate()
+
+    @pytest.mark.asyncio
+    async def test_validate_skips_if_already_validated(self) -> None:
+        """Skips validation if already validated."""
+        publisher = TelegramPublisher(token="test-token")
+        publisher._validated = True
+
+        # Should not raise or call any external code
+        await publisher.validate()
+        assert publisher._validated is True
+
+    @pytest.mark.asyncio
+    async def test_validate_success(self) -> None:
+        """Successful validation sets _validated flag."""
+        publisher = TelegramPublisher(token="test-token")
+
+        mock_bot = MagicMock()
+        mock_me = MagicMock()
+        mock_me.username = "test_bot"
+        mock_bot.get_me = AsyncMock(return_value=mock_me)
+
+        with patch("claude_session_player.watcher.telegram_publisher.check_telegram_available", return_value=True):
+            with patch(
+                "aiogram.Bot", return_value=mock_bot
+            ):
+                await publisher.validate()
+
+        assert publisher._validated is True
+        assert publisher._bot is mock_bot
+
+    @pytest.mark.asyncio
+    async def test_validate_auth_failure(self) -> None:
+        """Auth failure raises TelegramAuthError."""
+        publisher = TelegramPublisher(token="invalid-token")
+
+        mock_bot = MagicMock()
+        mock_bot.get_me = AsyncMock(
+            side_effect=make_telegram_api_error("Unauthorized", "get_me")
+        )
+
+        with patch("claude_session_player.watcher.telegram_publisher.check_telegram_available", return_value=True):
+            with patch(
+                "aiogram.Bot", return_value=mock_bot
+            ):
+                with pytest.raises(TelegramAuthError, match="validation failed"):
+                    await publisher.validate()
+
+    @pytest.mark.asyncio
+    async def test_validate_aiogram_not_installed(self) -> None:
+        """Raises TelegramError if aiogram not installed."""
+        publisher = TelegramPublisher(token="test-token")
+
+        with patch("claude_session_player.watcher.telegram_publisher.check_telegram_available", return_value=False):
+            with pytest.raises(TelegramError, match="aiogram library not installed"):
+                await publisher.validate()
+
+
+class TestTelegramPublisherSendMessage:
+    """Tests for TelegramPublisher.send_message()."""
+
+    @pytest.fixture
+    def validated_publisher(self) -> TelegramPublisher:
+        """Create a pre-validated publisher with mock bot."""
+        publisher = TelegramPublisher(token="test-token")
+        publisher._validated = True
+        publisher._bot = MagicMock()
+        return publisher
+
+    @pytest.mark.asyncio
+    async def test_send_message_success(self, validated_publisher: TelegramPublisher) -> None:
+        """Successfully sends message."""
+        mock_result = MagicMock()
+        mock_result.message_id = 123
+        validated_publisher._bot.send_message = AsyncMock(return_value=mock_result)
+
+        message_id = await validated_publisher.send_message(
+            chat_id="123456789",
+            text="Hello world",
+        )
+
+        assert message_id == 123
+        validated_publisher._bot.send_message.assert_called_once_with(
+            chat_id="123456789",
+            text="Hello world",
+            parse_mode="Markdown",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_message_truncates_long_text(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Truncates long messages."""
+        mock_result = MagicMock()
+        mock_result.message_id = 123
+        validated_publisher._bot.send_message = AsyncMock(return_value=mock_result)
+
+        long_text = "x" * 5000
+        await validated_publisher.send_message(
+            chat_id="123456789",
+            text=long_text,
+        )
+
+        # Check the text was truncated
+        call_args = validated_publisher._bot.send_message.call_args
+        sent_text = call_args.kwargs["text"]
+        assert len(sent_text) <= 4096
+        assert sent_text.endswith("... [truncated]")
+
+    @pytest.mark.asyncio
+    async def test_send_message_retry_on_failure(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Retries once on API failure."""
+        mock_result = MagicMock()
+        mock_result.message_id = 123
+
+        # First call fails, second succeeds
+        validated_publisher._bot.send_message = AsyncMock(
+            side_effect=[
+                make_telegram_api_error("Temporary error", "send"),
+                mock_result,
+            ]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            message_id = await validated_publisher.send_message(
+                chat_id="123456789",
+                text="Hello",
+            )
+
+        assert message_id == 123
+        assert validated_publisher._bot.send_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_message_raises_after_retry_fails(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Raises TelegramError after retry fails."""
+        validated_publisher._bot.send_message = AsyncMock(
+            side_effect=make_telegram_api_error("Permanent error", "send")
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(TelegramError, match="Send failed"):
+                await validated_publisher.send_message(
+                    chat_id="123456789",
+                    text="Hello",
+                )
+
+    @pytest.mark.asyncio
+    async def test_send_message_validates_first(self) -> None:
+        """Validates before sending if not validated."""
+        publisher = TelegramPublisher(token="test-token")
+
+        mock_bot = MagicMock()
+        mock_me = MagicMock()
+        mock_me.username = "test_bot"
+        mock_bot.get_me = AsyncMock(return_value=mock_me)
+
+        mock_result = MagicMock()
+        mock_result.message_id = 123
+        mock_bot.send_message = AsyncMock(return_value=mock_result)
+
+        with patch("claude_session_player.watcher.telegram_publisher.check_telegram_available", return_value=True):
+            with patch("aiogram.Bot", return_value=mock_bot):
+                message_id = await publisher.send_message(
+                    chat_id="123456789",
+                    text="Hello",
+                )
+
+        assert message_id == 123
+        assert publisher._validated is True
+
+
+class TestTelegramPublisherEditMessage:
+    """Tests for TelegramPublisher.edit_message()."""
+
+    @pytest.fixture
+    def validated_publisher(self) -> TelegramPublisher:
+        """Create a pre-validated publisher with mock bot."""
+        publisher = TelegramPublisher(token="test-token")
+        publisher._validated = True
+        publisher._bot = MagicMock()
+        return publisher
+
+    @pytest.mark.asyncio
+    async def test_edit_message_success(self, validated_publisher: TelegramPublisher) -> None:
+        """Successfully edits message."""
+        validated_publisher._bot.edit_message_text = AsyncMock()
+
+        result = await validated_publisher.edit_message(
+            chat_id="123456789",
+            message_id=123,
+            text="Updated text",
+        )
+
+        assert result is True
+        validated_publisher._bot.edit_message_text.assert_called_once_with(
+            chat_id="123456789",
+            message_id=123,
+            text="Updated text",
+            parse_mode="Markdown",
+        )
+
+    @pytest.mark.asyncio
+    async def test_edit_message_not_modified_returns_true(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Returns True when message is not modified."""
+        validated_publisher._bot.edit_message_text = AsyncMock(
+            side_effect=make_telegram_api_error("message is not modified", "edit")
+        )
+
+        result = await validated_publisher.edit_message(
+            chat_id="123456789",
+            message_id=123,
+            text="Same text",
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_edit_message_not_found_returns_false(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Returns False when message not found."""
+        validated_publisher._bot.edit_message_text = AsyncMock(
+            side_effect=make_telegram_api_error("message to edit not found", "edit")
+        )
+
+        result = await validated_publisher.edit_message(
+            chat_id="123456789",
+            message_id=123,
+            text="Updated text",
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_edit_message_retry_on_failure(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Retries once on API failure."""
+        # First call fails, second succeeds
+        validated_publisher._bot.edit_message_text = AsyncMock(
+            side_effect=[
+                make_telegram_api_error("Temporary error", "edit"),
+                None,  # Success returns None for edit
+            ]
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await validated_publisher.edit_message(
+                chat_id="123456789",
+                message_id=123,
+                text="Updated",
+            )
+
+        assert result is True
+        assert validated_publisher._bot.edit_message_text.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_edit_message_returns_false_after_retry_fails(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Returns False after retry fails."""
+        validated_publisher._bot.edit_message_text = AsyncMock(
+            side_effect=make_telegram_api_error("Permanent error", "edit")
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await validated_publisher.edit_message(
+                chat_id="123456789",
+                message_id=123,
+                text="Updated",
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_edit_message_truncates_long_text(
+        self, validated_publisher: TelegramPublisher
+    ) -> None:
+        """Truncates long messages."""
+        validated_publisher._bot.edit_message_text = AsyncMock()
+
+        long_text = "x" * 5000
+        await validated_publisher.edit_message(
+            chat_id="123456789",
+            message_id=123,
+            text=long_text,
+        )
+
+        call_args = validated_publisher._bot.edit_message_text.call_args
+        sent_text = call_args.kwargs["text"]
+        assert len(sent_text) <= 4096
+        assert sent_text.endswith("... [truncated]")
+
+
+class TestTelegramPublisherClose:
+    """Tests for TelegramPublisher.close()."""
+
+    @pytest.mark.asyncio
+    async def test_close_with_bot(self) -> None:
+        """Close shuts down bot session."""
+        publisher = TelegramPublisher(token="test-token")
+        publisher._validated = True
+
+        mock_session = AsyncMock()
+        publisher._bot = MagicMock()
+        publisher._bot.session = mock_session
+
+        await publisher.close()
+
+        mock_session.close.assert_called_once()
+        assert publisher._bot is None
+        assert publisher._validated is False
+
+    @pytest.mark.asyncio
+    async def test_close_without_bot(self) -> None:
+        """Close handles no bot gracefully."""
+        publisher = TelegramPublisher(token="test-token")
+        publisher._bot = None
+
+        # Should not raise
+        await publisher.close()
+        assert publisher._bot is None
+
+
+# ---------------------------------------------------------------------------
+# Module import tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    """Tests for module imports and __all__."""
+
+    def test_import_telegram_publisher_from_watcher(self) -> None:
+        """Can import TelegramPublisher from watcher package."""
+        from claude_session_player.watcher import TelegramPublisher as TP
+
+        assert TP is TelegramPublisher
+
+    def test_import_exceptions_from_watcher(self) -> None:
+        """Can import exceptions from watcher package."""
+        from claude_session_player.watcher import TelegramAuthError as TAE
+        from claude_session_player.watcher import TelegramError as TE
+
+        assert TE is TelegramError
+        assert TAE is TelegramAuthError
+
+    def test_import_formatting_functions_from_watcher(self) -> None:
+        """Can import formatting functions from watcher package."""
+        from claude_session_player.watcher import (
+            escape_markdown as em,
+            format_context_compacted as fcc,
+            format_system_message as fsm,
+            format_turn_message as ftm,
+            format_user_message as fum,
+            get_tool_icon as gti,
+        )
+
+        assert em is escape_markdown
+        assert fcc is format_context_compacted
+        assert fsm is format_system_message
+        assert ftm is format_turn_message
+        assert fum is format_user_message
+        assert gti is get_tool_icon
+
+    def test_import_tool_call_info_from_watcher(self) -> None:
+        """Can import ToolCallInfo from watcher package."""
+        from claude_session_player.watcher import ToolCallInfo as TCI
+
+        assert TCI is ToolCallInfo
+
+    def test_exports_in_all(self) -> None:
+        """All exports are in __all__."""
+        from claude_session_player import watcher
+
+        assert "TelegramPublisher" in watcher.__all__
+        assert "TelegramError" in watcher.__all__
+        assert "TelegramAuthError" in watcher.__all__
+        assert "ToolCallInfo" in watcher.__all__
+        assert "escape_markdown" in watcher.__all__
+        assert "format_user_message" in watcher.__all__
+        assert "format_turn_message" in watcher.__all__
+        assert "format_system_message" in watcher.__all__
+        assert "format_context_compacted" in watcher.__all__
+        assert "get_tool_icon" in watcher.__all__


### PR DESCRIPTION
## Summary

- Add `TelegramPublisher` class for sending and editing messages via Telegram Bot API using aiogram
- Implement custom exceptions (`TelegramError`, `TelegramAuthError`) for error handling
- Add message formatting utilities for Telegram Markdown
- Handle Telegram's 4096 character limit with automatic truncation
- Implement retry logic for transient API failures
- Add 55 comprehensive unit tests

## Changes

### New Files
- `claude_session_player/watcher/telegram_publisher.py` - Main publisher class and utilities
- `tests/watcher/test_telegram_publisher.py` - Unit tests (55 tests)
- `issues/worklogs/71-worklog.md` - Development worklog

### Modified Files  
- `claude_session_player/watcher/__init__.py` - Added exports for new classes/functions

## Features

- **TelegramPublisher class**: Async publisher with `validate()`, `send_message()`, `edit_message()`, and `close()` methods
- **Message formatting**: `format_user_message()`, `format_turn_message()`, `format_system_message()`, `format_context_compacted()`
- **Markdown escaping**: Properly escapes `_`, `*`, `` ` ``, `[` characters
- **Tool icons**: Maps tool names to emoji (📖 Read, 📝 Write, ✏️ Edit, 🔧 Bash, etc.)
- **Error handling**: Graceful handling of "message is not modified" and "message to edit not found" errors
- **Retry logic**: Single retry with 1s delay on transient failures
- **Graceful degradation**: Helpful error message when aiogram not installed

## Test plan

- [x] All 55 unit tests pass
- [x] Full test suite passes (967 tests)
- [x] Tests cover validation, send, edit, retry, truncation, and formatting

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)