### PR TITLE
Issue #73: Add MessageStateTracker for turn-based message grouping

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -15,6 +15,15 @@ from claude_session_player.watcher.deps import check_slack_available, check_tele
 from claude_session_player.watcher.destinations import AttachedDestination, DestinationManager
 from claude_session_player.watcher.event_buffer import EventBuffer, EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalReader
+from claude_session_player.watcher.message_state import (
+    MessageAction,
+    MessageStateTracker,
+    NoAction,
+    SendNewMessage,
+    SessionMessageState,
+    TurnState,
+    UpdateExistingMessage,
+)
 from claude_session_player.watcher.service import WatcherService
 from claude_session_player.watcher.sse import SSEConnection, SSEManager
 from claude_session_player.watcher.state import SessionState, StateManager
@@ -66,8 +75,13 @@ __all__ = [
     "format_user_message_blocks",
     "get_tool_icon",
     "IncrementalReader",
+    "MessageAction",
+    "MessageStateTracker",
+    "NoAction",
+    "SendNewMessage",
     "SessionConfig",
     "SessionDestinations",
+    "SessionMessageState",
     "SessionState",
     "SlackAuthError",
     "SlackDestination",
@@ -83,6 +97,8 @@ __all__ = [
     "TelegramError",
     "TelegramPublisher",
     "ToolCallInfo",
+    "TurnState",
+    "UpdateExistingMessage",
     "WatcherAPI",
     "WatcherService",
     "transform",

--- a/claude_session_player/watcher/message_state.py
+++ b/claude_session_player/watcher/message_state.py
@@ -1,0 +1,516 @@
+"""Message state tracking for turn-based message grouping.
+
+This module tracks message state across Telegram and Slack destinations,
+handling turn-based grouping of events into messages.
+
+Turn grouping rules:
+- A turn starts with an ASSISTANT block (after a USER block)
+- A turn includes all ASSISTANT, TOOL_CALL, and DURATION blocks until the next USER block
+- USER blocks get their own message
+- SYSTEM blocks and ClearAll get their own messages
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Union
+from uuid import uuid4
+
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    Event,
+    SystemContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from claude_session_player.watcher.telegram_publisher import (
+    ToolCallInfo,
+    format_context_compacted,
+    format_system_message,
+    format_turn_message,
+    format_user_message,
+    get_tool_icon,
+)
+from claude_session_player.watcher.slack_publisher import (
+    ToolCallInfo as SlackToolCallInfo,
+    format_context_compacted_blocks,
+    format_system_message_blocks,
+    format_turn_message_blocks,
+    format_user_message_blocks,
+    get_tool_icon as slack_get_tool_icon,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data Structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TurnState:
+    """State of a single turn being built."""
+
+    turn_id: str
+    assistant_text: str = ""
+    tool_calls: list[ToolCallInfo] = field(default_factory=list)
+    duration_ms: int | None = None
+    finalized: bool = False
+
+    # Message IDs per destination (ephemeral, not persisted)
+    telegram_messages: dict[str, int] = field(default_factory=dict)  # chat_id -> message_id
+    slack_messages: dict[str, str] = field(default_factory=dict)  # channel -> ts
+
+    # Track tool_use_id to tool_call index for updates
+    tool_use_id_to_index: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class SessionMessageState:
+    """Message state for a single session."""
+
+    session_id: str
+    current_turn: TurnState | None = None
+
+
+# ---------------------------------------------------------------------------
+# MessageAction Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SendNewMessage:
+    """Send a new message to all destinations."""
+
+    turn_id: str
+    message_type: Literal["user", "turn", "system"]
+    content: str  # For Telegram
+    blocks: list[dict]  # For Slack
+    text_fallback: str  # For Slack notifications
+
+
+@dataclass
+class UpdateExistingMessage:
+    """Update an existing message at all destinations."""
+
+    turn_id: str
+    content: str  # For Telegram
+    blocks: list[dict]  # For Slack
+    text_fallback: str  # For Slack notifications
+
+
+@dataclass
+class NoAction:
+    """No messaging action needed."""
+
+    reason: str
+
+
+MessageAction = Union[SendNewMessage, UpdateExistingMessage, NoAction]
+
+
+# ---------------------------------------------------------------------------
+# MessageStateTracker
+# ---------------------------------------------------------------------------
+
+
+class MessageStateTracker:
+    """Tracks message state for turn-based message grouping.
+
+    This class processes events and determines what messaging action to take
+    (send new message, update existing, or no action). It also tracks message
+    IDs per destination so updates can be sent to the correct messages.
+
+    State is ephemeral - not persisted across restarts. On restart, we lose
+    ability to update old messages and start fresh.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the tracker."""
+        self._sessions: dict[str, SessionMessageState] = {}
+
+    def get_session_state(self, session_id: str) -> SessionMessageState:
+        """Get or create session state.
+
+        Args:
+            session_id: The session identifier.
+
+        Returns:
+            SessionMessageState for the session.
+        """
+        if session_id not in self._sessions:
+            self._sessions[session_id] = SessionMessageState(session_id=session_id)
+        return self._sessions[session_id]
+
+    def handle_event(
+        self,
+        session_id: str,
+        event: Event,
+    ) -> MessageAction:
+        """Process an event and determine the messaging action.
+
+        Args:
+            session_id: The session identifier.
+            event: The event to process.
+
+        Returns:
+            MessageAction indicating what to do (send new, update existing, etc.)
+        """
+        state = self.get_session_state(session_id)
+
+        if isinstance(event, AddBlock):
+            return self._handle_add_block(state, event.block)
+        elif isinstance(event, UpdateBlock):
+            return self._handle_update_block(state, event)
+        elif isinstance(event, ClearAll):
+            return self._handle_clear_all(state)
+        else:
+            return NoAction(reason=f"Unknown event type: {type(event)}")
+
+    def record_message_id(
+        self,
+        session_id: str,
+        turn_id: str,
+        destination_type: str,
+        identifier: str,
+        message_id: int | str,
+    ) -> None:
+        """Record the message ID after sending to a destination.
+
+        Args:
+            session_id: The session identifier.
+            turn_id: The turn identifier.
+            destination_type: "telegram" or "slack".
+            identifier: chat_id for Telegram, channel for Slack.
+            message_id: The message ID (int for Telegram, str for Slack).
+        """
+        state = self.get_session_state(session_id)
+        if state.current_turn and state.current_turn.turn_id == turn_id:
+            if destination_type == "telegram":
+                state.current_turn.telegram_messages[identifier] = int(message_id)
+            elif destination_type == "slack":
+                state.current_turn.slack_messages[identifier] = str(message_id)
+
+    def get_message_id(
+        self,
+        session_id: str,
+        turn_id: str,
+        destination_type: str,
+        identifier: str,
+    ) -> int | str | None:
+        """Get the message ID for a turn at a destination.
+
+        Args:
+            session_id: The session identifier.
+            turn_id: The turn identifier.
+            destination_type: "telegram" or "slack".
+            identifier: chat_id for Telegram, channel for Slack.
+
+        Returns:
+            The message ID if found, None otherwise.
+        """
+        state = self.get_session_state(session_id)
+        if state.current_turn and state.current_turn.turn_id == turn_id:
+            if destination_type == "telegram":
+                return state.current_turn.telegram_messages.get(identifier)
+            elif destination_type == "slack":
+                return state.current_turn.slack_messages.get(identifier)
+        return None
+
+    def clear_session(self, session_id: str) -> None:
+        """Clear all state for a session.
+
+        Args:
+            session_id: The session identifier.
+        """
+        if session_id in self._sessions:
+            del self._sessions[session_id]
+
+    def render_replay(
+        self,
+        session_id: str,
+        events: list[Event],
+    ) -> tuple[str, list[dict]]:
+        """Render multiple events as a single catch-up message.
+
+        Used when replay_count > 0 on attach.
+
+        Args:
+            session_id: The session identifier.
+            events: List of events to render.
+
+        Returns:
+            Tuple of (telegram_text, slack_blocks).
+        """
+        if not events:
+            return "", []
+
+        # Count events by type
+        user_count = 0
+        assistant_count = 0
+        tool_count = 0
+
+        for event in events:
+            if isinstance(event, AddBlock):
+                if event.block.type == BlockType.USER:
+                    user_count += 1
+                elif event.block.type == BlockType.ASSISTANT:
+                    assistant_count += 1
+                elif event.block.type == BlockType.TOOL_CALL:
+                    tool_count += 1
+
+        # Build Telegram text
+        text_parts = [f"📜 *Catching up* ({len(events)} events)\n"]
+        if user_count:
+            text_parts.append(f"\n👤 User messages: {user_count}")
+        if assistant_count:
+            text_parts.append(f"\n🤖 Assistant turns: {assistant_count}")
+        if tool_count:
+            text_parts.append(f"\n🔧 Tool calls: {tool_count}")
+
+        telegram_text = "".join(text_parts)
+
+        # Build Slack blocks
+        blocks: list[dict] = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"📜 *Catching up* ({len(events)} events)",
+                },
+            }
+        ]
+
+        summary_parts = []
+        if user_count:
+            summary_parts.append(f"👤 User messages: {user_count}")
+        if assistant_count:
+            summary_parts.append(f"🤖 Assistant turns: {assistant_count}")
+        if tool_count:
+            summary_parts.append(f"🔧 Tool calls: {tool_count}")
+
+        if summary_parts:
+            blocks.append({"type": "divider"})
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "\n".join(summary_parts)},
+                }
+            )
+
+        return telegram_text, blocks
+
+    # -------------------------------------------------------------------------
+    # Private Methods
+    # -------------------------------------------------------------------------
+
+    def _handle_add_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle an AddBlock event."""
+        if block.type == BlockType.USER:
+            return self._handle_user_block(state, block)
+        elif block.type == BlockType.ASSISTANT:
+            return self._handle_assistant_block(state, block)
+        elif block.type == BlockType.TOOL_CALL:
+            return self._handle_tool_call_block(state, block)
+        elif block.type == BlockType.DURATION:
+            return self._handle_duration_block(state, block)
+        elif block.type == BlockType.SYSTEM:
+            return self._handle_system_block(state, block)
+        elif block.type == BlockType.THINKING:
+            # Thinking blocks don't produce messages
+            return NoAction(reason="Thinking blocks are not displayed")
+        elif block.type == BlockType.QUESTION:
+            # Questions are handled like tool calls but we don't have special formatting yet
+            return NoAction(reason="Question blocks not yet supported in messaging")
+        else:
+            return NoAction(reason=f"Unhandled block type: {block.type}")
+
+    def _handle_user_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle a USER block - creates new message and finalizes previous turn."""
+        # Finalize current turn (if any)
+        if state.current_turn and not state.current_turn.finalized:
+            state.current_turn.finalized = True
+
+        # Get user text
+        if isinstance(block.content, UserContent):
+            text = block.content.text
+        else:
+            text = ""
+
+        # Format for Telegram and Slack
+        content = format_user_message(text)
+        blocks = format_user_message_blocks(text)
+        text_fallback = f"User: {text[:100]}" if text else "User message"
+
+        return SendNewMessage(
+            turn_id=f"user-{block.id}",
+            message_type="user",
+            content=content,
+            blocks=blocks,
+            text_fallback=text_fallback,
+        )
+
+    def _handle_assistant_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle an ASSISTANT block - starts or continues a turn."""
+        # Start new turn if none exists or previous is finalized
+        if state.current_turn is None or state.current_turn.finalized:
+            state.current_turn = TurnState(turn_id=f"turn-{block.id}")
+
+        # Add assistant text
+        if isinstance(block.content, AssistantContent):
+            if state.current_turn.assistant_text:
+                state.current_turn.assistant_text += "\n\n"
+            state.current_turn.assistant_text += block.content.text
+
+        return self._render_turn_action(state.current_turn)
+
+    def _handle_tool_call_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle a TOOL_CALL block - adds to current turn."""
+        # Start new turn if none exists
+        if state.current_turn is None:
+            state.current_turn = TurnState(turn_id=f"turn-{block.id}")
+
+        if isinstance(block.content, ToolCallContent):
+            tool_info = ToolCallInfo(
+                name=block.content.tool_name,
+                label=block.content.label or "",
+                icon=get_tool_icon(block.content.tool_name),
+                result=block.content.result,
+                is_error=block.content.is_error,
+            )
+            # Track tool_use_id -> index for updates
+            idx = len(state.current_turn.tool_calls)
+            state.current_turn.tool_use_id_to_index[block.content.tool_use_id] = idx
+            state.current_turn.tool_calls.append(tool_info)
+
+        return self._render_turn_action(state.current_turn)
+
+    def _handle_duration_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle a DURATION block - adds footer to current turn."""
+        if state.current_turn:
+            if isinstance(block.content, DurationContent):
+                state.current_turn.duration_ms = block.content.duration_ms
+            return self._render_turn_action(state.current_turn)
+        return NoAction(reason="Duration without turn")
+
+    def _handle_system_block(
+        self, state: SessionMessageState, block: Block
+    ) -> MessageAction:
+        """Handle a SYSTEM block - creates standalone message."""
+        if isinstance(block.content, SystemContent):
+            text = block.content.text
+        else:
+            text = ""
+
+        content = format_system_message(text)
+        blocks = format_system_message_blocks(text)
+        text_fallback = f"System: {text}"
+
+        return SendNewMessage(
+            turn_id=f"system-{block.id}",
+            message_type="system",
+            content=content,
+            blocks=blocks,
+            text_fallback=text_fallback,
+        )
+
+    def _handle_update_block(
+        self, state: SessionMessageState, event: UpdateBlock
+    ) -> MessageAction:
+        """Handle an UpdateBlock event - update tool result in current turn."""
+        if not state.current_turn:
+            return NoAction(reason="Update without current turn")
+
+        # UpdateBlock contains updated content, usually ToolCallContent with result
+        if isinstance(event.content, ToolCallContent):
+            tool_use_id = event.content.tool_use_id
+            if tool_use_id in state.current_turn.tool_use_id_to_index:
+                idx = state.current_turn.tool_use_id_to_index[tool_use_id]
+                tool = state.current_turn.tool_calls[idx]
+                # Update the result
+                tool.result = event.content.result
+                tool.is_error = event.content.is_error
+                return self._render_turn_action(state.current_turn)
+
+        return NoAction(reason="Update for unknown block")
+
+    def _handle_clear_all(self, state: SessionMessageState) -> MessageAction:
+        """Handle a ClearAll event - context compaction."""
+        # Finalize current turn
+        if state.current_turn:
+            state.current_turn.finalized = True
+        state.current_turn = None
+
+        # Send context compacted message
+        content = format_context_compacted()
+        blocks = format_context_compacted_blocks()
+
+        return SendNewMessage(
+            turn_id=f"clear-{uuid4().hex[:8]}",
+            message_type="system",
+            content=content,
+            blocks=blocks,
+            text_fallback="Context compacted",
+        )
+
+    def _render_turn_action(self, turn: TurnState) -> MessageAction:
+        """Render the turn as a message action."""
+        # Convert ToolCallInfo to SlackToolCallInfo for Slack formatting
+        slack_tool_calls = [
+            SlackToolCallInfo(
+                name=t.name,
+                label=t.label,
+                icon=slack_get_tool_icon(t.name),
+                result=t.result,
+                is_error=t.is_error,
+            )
+            for t in turn.tool_calls
+        ]
+
+        content = format_turn_message(
+            turn.assistant_text or None,
+            turn.tool_calls,
+            turn.duration_ms,
+        )
+        blocks = format_turn_message_blocks(
+            turn.assistant_text or None,
+            slack_tool_calls,
+            turn.duration_ms,
+        )
+        text_fallback = (
+            f"Assistant: {turn.assistant_text[:100]}..."
+            if turn.assistant_text
+            else "Assistant response"
+        )
+
+        # If we have message IDs, it's an update; otherwise it's new
+        if turn.telegram_messages or turn.slack_messages:
+            return UpdateExistingMessage(
+                turn_id=turn.turn_id,
+                content=content,
+                blocks=blocks,
+                text_fallback=text_fallback,
+            )
+        else:
+            return SendNewMessage(
+                turn_id=turn.turn_id,
+                message_type="turn",
+                content=content,
+                blocks=blocks,
+                text_fallback=text_fallback,
+            )

--- a/issues/worklogs/73-worklog.md
+++ b/issues/worklogs/73-worklog.md
@@ -1,0 +1,128 @@
+# Issue #73: Add MessageStateTracker for turn-based message grouping
+
+## Summary
+
+Implemented `MessageStateTracker` class for tracking message state across Telegram and Slack, handling turn-based grouping of events into messages. This component is essential for the messaging integration, determining when to send new messages vs update existing ones based on the turn grouping rules.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/message_state.py`**
+   - `TurnState`: Dataclass tracking state of a single turn being built
+   - `SessionMessageState`: Dataclass tracking message state for a single session
+   - `SendNewMessage`: Action to send a new message to all destinations
+   - `UpdateExistingMessage`: Action to update an existing message
+   - `NoAction`: Action indicating no messaging action needed
+   - `MessageAction`: Union type of all action types
+   - `MessageStateTracker` class implementing:
+     - `get_session_state()`: Get or create session state
+     - `handle_event()`: Process event and determine messaging action
+     - `record_message_id()`: Record message ID after sending
+     - `get_message_id()`: Get message ID for a turn at a destination
+     - `clear_session()`: Clear all state for a session
+     - `render_replay()`: Render events as batched catch-up message
+
+2. **`tests/watcher/test_message_state.py`**
+   - 47 tests covering all functionality
+
+### Modified Files
+
+1. **`claude_session_player/watcher/__init__.py`**
+   - Added imports for all new classes from message_state module
+   - Updated `__all__` list with 7 new exports
+
+## Design Decisions
+
+### Turn Grouping Logic
+
+Implemented the turn grouping rules from the spec:
+- USER blocks create new messages and finalize previous turns
+- ASSISTANT blocks start or continue turns (multiple ASSISTANT blocks concatenate)
+- TOOL_CALL blocks are added to the current turn
+- DURATION blocks are added as footers to the current turn
+- SYSTEM blocks create standalone messages
+- ClearAll events send "Context compacted" messages and clear state
+
+### Message ID Tracking
+
+Message IDs are tracked per-turn per-destination:
+- Telegram: `dict[str, int]` mapping chat_id to message_id
+- Slack: `dict[str, str]` mapping channel to timestamp
+
+When a turn has message IDs recorded, subsequent events for that turn produce `UpdateExistingMessage` actions; otherwise they produce `SendNewMessage` actions.
+
+### Tool Result Updates
+
+Tool results are tracked by `tool_use_id` using an index mapping (`tool_use_id_to_index`). When an `UpdateBlock` event arrives, we look up the tool by its `tool_use_id` and update its result in place.
+
+### Formatting Utilities
+
+Imported formatting utilities from TelegramPublisher and SlackPublisher modules:
+- `format_user_message()` / `format_user_message_blocks()`
+- `format_turn_message()` / `format_turn_message_blocks()`
+- `format_system_message()` / `format_system_message_blocks()`
+- `format_context_compacted()` / `format_context_compacted_blocks()`
+- `get_tool_icon()` / `slack_get_tool_icon()`
+
+### Python 3.9 Compatibility
+
+Used `Union[A, B, C]` syntax for the `MessageAction` type alias instead of the `A | B | C` syntax, since the test environment runs Python 3.9 which doesn't support the `|` syntax for type aliases at runtime.
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestTurnState | 2 | dataclass creation |
+| TestSessionMessageState | 2 | dataclass creation |
+| TestMessageActionTypes | 3 | action type creation |
+| TestMessageStateTrackerBasic | 4 | session state management |
+| TestHandleUserBlock | 3 | user block handling |
+| TestHandleAssistantBlock | 3 | assistant block handling |
+| TestHandleToolCallBlock | 5 | tool call block handling |
+| TestHandleDurationBlock | 2 | duration block handling |
+| TestHandleSystemBlock | 2 | system block handling |
+| TestHandleUpdateBlock | 4 | update block handling |
+| TestHandleClearAll | 3 | clear all handling |
+| TestMessageIdTracking | 5 | message ID tracking |
+| TestReplayRendering | 3 | replay rendering |
+| TestOtherBlockTypes | 1 | thinking blocks |
+| TestTurnGroupingIntegration | 2 | integration tests |
+| TestModuleImports | 3 | package imports |
+
+## Test Results
+
+- **Before:** 1024 tests
+- **After:** 1071 tests (47 new)
+- All new tests pass
+
+## Acceptance Criteria Status
+
+- [x] `MessageStateTracker` class in `claude_session_player/watcher/message_state.py`
+- [x] `TurnState` and `SessionMessageState` dataclasses
+- [x] `MessageAction` union type with `SendNewMessage`, `UpdateExistingMessage`, `NoAction`
+- [x] `handle_event()` correctly maps events to actions:
+  - [x] USER → SendNewMessage + finalize previous turn
+  - [x] ASSISTANT → SendNewMessage or UpdateExistingMessage (depending on state)
+  - [x] TOOL_CALL → UpdateExistingMessage (add to turn)
+  - [x] DURATION → UpdateExistingMessage (add footer)
+  - [x] SYSTEM → SendNewMessage
+  - [x] ClearAll → SendNewMessage (context compacted) + clear state
+- [x] `record_message_id()` and `get_message_id()` for tracking sent messages
+- [x] `render_replay()` produces batched catch-up content
+- [x] Unit tests cover:
+  - [x] Turn grouping: assistant + tools + duration in one turn
+  - [x] Turn finalization on USER
+  - [x] Multiple consecutive ASSISTANT blocks in one turn
+  - [x] UpdateBlock handling for tool results
+  - [x] ClearAll handling
+  - [x] Message ID tracking
+  - [x] Replay rendering
+- [x] Formatting utilities imported from TelegramPublisher/SlackPublisher
+
+## Spec Reference
+
+Implements issue #73 from `.claude/specs/messaging-integration.md`:
+- MessageStateTracker component for turn-based message grouping
+- Ephemeral state management (not persisted)
+- Integration with Telegram and Slack formatting utilities

--- a/tests/watcher/test_message_state.py
+++ b/tests/watcher/test_message_state.py
@@ -1,0 +1,960 @@
+"""Tests for MessageStateTracker."""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    SystemContent,
+    ThinkingContent,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from claude_session_player.watcher.message_state import (
+    MessageAction,
+    MessageStateTracker,
+    NoAction,
+    SendNewMessage,
+    SessionMessageState,
+    TurnState,
+    UpdateExistingMessage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tracker() -> MessageStateTracker:
+    """Create a fresh MessageStateTracker for each test."""
+    return MessageStateTracker()
+
+
+def make_user_block(block_id: str = "u1", text: str = "Hello") -> Block:
+    """Create a user block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.USER,
+        content=UserContent(text=text),
+    )
+
+
+def make_assistant_block(block_id: str = "a1", text: str = "Hi there") -> Block:
+    """Create an assistant block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.ASSISTANT,
+        content=AssistantContent(text=text),
+    )
+
+
+def make_tool_call_block(
+    block_id: str = "t1",
+    tool_name: str = "Read",
+    tool_use_id: str = "tu1",
+    label: str = "src/main.py",
+    result: str | None = None,
+    is_error: bool = False,
+) -> Block:
+    """Create a tool call block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.TOOL_CALL,
+        content=ToolCallContent(
+            tool_name=tool_name,
+            tool_use_id=tool_use_id,
+            label=label,
+            result=result,
+            is_error=is_error,
+        ),
+    )
+
+
+def make_duration_block(block_id: str = "d1", duration_ms: int = 5000) -> Block:
+    """Create a duration block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.DURATION,
+        content=DurationContent(duration_ms=duration_ms),
+    )
+
+
+def make_system_block(block_id: str = "s1", text: str = "System message") -> Block:
+    """Create a system block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.SYSTEM,
+        content=SystemContent(text=text),
+    )
+
+
+def make_thinking_block(block_id: str = "th1") -> Block:
+    """Create a thinking block for testing."""
+    return Block(
+        id=block_id,
+        type=BlockType.THINKING,
+        content=ThinkingContent(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test TurnState
+# ---------------------------------------------------------------------------
+
+
+class TestTurnState:
+    """Tests for TurnState dataclass."""
+
+    def test_create_default(self) -> None:
+        """Test creating TurnState with defaults."""
+        turn = TurnState(turn_id="turn-1")
+        assert turn.turn_id == "turn-1"
+        assert turn.assistant_text == ""
+        assert turn.tool_calls == []
+        assert turn.duration_ms is None
+        assert turn.finalized is False
+        assert turn.telegram_messages == {}
+        assert turn.slack_messages == {}
+        assert turn.tool_use_id_to_index == {}
+
+    def test_create_with_values(self) -> None:
+        """Test creating TurnState with values."""
+        from claude_session_player.watcher.telegram_publisher import ToolCallInfo
+
+        turn = TurnState(
+            turn_id="turn-1",
+            assistant_text="Hello",
+            tool_calls=[ToolCallInfo(name="Read", label="test.py", icon="📖")],
+            duration_ms=5000,
+            finalized=True,
+            telegram_messages={"123": 456},
+            slack_messages={"C123": "ts123"},
+        )
+        assert turn.turn_id == "turn-1"
+        assert turn.assistant_text == "Hello"
+        assert len(turn.tool_calls) == 1
+        assert turn.duration_ms == 5000
+        assert turn.finalized is True
+        assert turn.telegram_messages == {"123": 456}
+        assert turn.slack_messages == {"C123": "ts123"}
+
+
+class TestSessionMessageState:
+    """Tests for SessionMessageState dataclass."""
+
+    def test_create_default(self) -> None:
+        """Test creating SessionMessageState with defaults."""
+        state = SessionMessageState(session_id="sess-1")
+        assert state.session_id == "sess-1"
+        assert state.current_turn is None
+
+    def test_create_with_turn(self) -> None:
+        """Test creating SessionMessageState with a turn."""
+        turn = TurnState(turn_id="turn-1")
+        state = SessionMessageState(session_id="sess-1", current_turn=turn)
+        assert state.current_turn is turn
+
+
+# ---------------------------------------------------------------------------
+# Test MessageAction Types
+# ---------------------------------------------------------------------------
+
+
+class TestMessageActionTypes:
+    """Tests for MessageAction types."""
+
+    def test_send_new_message(self) -> None:
+        """Test SendNewMessage creation."""
+        action = SendNewMessage(
+            turn_id="turn-1",
+            message_type="turn",
+            content="Hello",
+            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": "Hello"}}],
+            text_fallback="Hello fallback",
+        )
+        assert action.turn_id == "turn-1"
+        assert action.message_type == "turn"
+        assert action.content == "Hello"
+        assert len(action.blocks) == 1
+        assert action.text_fallback == "Hello fallback"
+
+    def test_update_existing_message(self) -> None:
+        """Test UpdateExistingMessage creation."""
+        action = UpdateExistingMessage(
+            turn_id="turn-1",
+            content="Updated",
+            blocks=[],
+            text_fallback="Updated fallback",
+        )
+        assert action.turn_id == "turn-1"
+        assert action.content == "Updated"
+
+    def test_no_action(self) -> None:
+        """Test NoAction creation."""
+        action = NoAction(reason="No reason")
+        assert action.reason == "No reason"
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - Basic Operations
+# ---------------------------------------------------------------------------
+
+
+class TestMessageStateTrackerBasic:
+    """Tests for basic MessageStateTracker operations."""
+
+    def test_get_session_state_creates_new(self, tracker: MessageStateTracker) -> None:
+        """Test get_session_state creates new state if not exists."""
+        state = tracker.get_session_state("sess-1")
+        assert state.session_id == "sess-1"
+        assert state.current_turn is None
+
+    def test_get_session_state_returns_existing(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test get_session_state returns existing state."""
+        state1 = tracker.get_session_state("sess-1")
+        state1.current_turn = TurnState(turn_id="turn-1")
+        state2 = tracker.get_session_state("sess-1")
+        assert state2.current_turn is not None
+        assert state2.current_turn.turn_id == "turn-1"
+
+    def test_clear_session(self, tracker: MessageStateTracker) -> None:
+        """Test clear_session removes session state."""
+        tracker.get_session_state("sess-1")
+        tracker.clear_session("sess-1")
+        # Getting state again should create fresh state
+        state = tracker.get_session_state("sess-1")
+        assert state.current_turn is None
+
+    def test_clear_session_nonexistent(self, tracker: MessageStateTracker) -> None:
+        """Test clear_session on non-existent session is safe."""
+        tracker.clear_session("nonexistent")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - USER Block Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleUserBlock:
+    """Tests for USER block handling."""
+
+    def test_user_block_sends_new_message(self, tracker: MessageStateTracker) -> None:
+        """Test USER block creates SendNewMessage."""
+        block = make_user_block(text="Hello world")
+        event = AddBlock(block=block)
+        action = tracker.handle_event("sess-1", event)
+
+        assert isinstance(action, SendNewMessage)
+        assert action.message_type == "user"
+        assert action.turn_id == "user-u1"
+        assert "Hello world" in action.content
+        assert "👤" in action.content
+        assert len(action.blocks) == 1
+
+    def test_user_block_finalizes_previous_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test USER block finalizes the previous turn."""
+        # Start a turn
+        assistant_block = make_assistant_block()
+        tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        state = tracker.get_session_state("sess-1")
+        assert state.current_turn is not None
+        assert not state.current_turn.finalized
+
+        # User block should finalize it
+        user_block = make_user_block()
+        tracker.handle_event("sess-1", AddBlock(block=user_block))
+
+        assert state.current_turn.finalized
+
+    def test_user_block_with_empty_text(self, tracker: MessageStateTracker) -> None:
+        """Test USER block with empty text."""
+        block = make_user_block(text="")
+        event = AddBlock(block=block)
+        action = tracker.handle_event("sess-1", event)
+
+        assert isinstance(action, SendNewMessage)
+        assert action.text_fallback == "User message"
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - ASSISTANT Block Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAssistantBlock:
+    """Tests for ASSISTANT block handling."""
+
+    def test_assistant_block_starts_new_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test ASSISTANT block starts a new turn."""
+        block = make_assistant_block(text="Hello!")
+        event = AddBlock(block=block)
+        action = tracker.handle_event("sess-1", event)
+
+        assert isinstance(action, SendNewMessage)
+        assert action.message_type == "turn"
+        assert "Hello!" in action.content
+        assert "🤖" in action.content
+
+    def test_assistant_block_continues_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test multiple ASSISTANT blocks continue the same turn."""
+        block1 = make_assistant_block(block_id="a1", text="First part")
+        block2 = make_assistant_block(block_id="a2", text="Second part")
+
+        action1 = tracker.handle_event("sess-1", AddBlock(block=block1))
+        assert isinstance(action1, SendNewMessage)
+
+        # Record message ID so next action is an update
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        action2 = tracker.handle_event("sess-1", AddBlock(block=block2))
+        assert isinstance(action2, UpdateExistingMessage)
+        assert "First part" in action2.content
+        assert "Second part" in action2.content
+
+    def test_assistant_block_after_finalized_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test ASSISTANT block after finalized turn starts new turn."""
+        # First turn
+        block1 = make_assistant_block(block_id="a1", text="First turn")
+        tracker.handle_event("sess-1", AddBlock(block=block1))
+
+        # Finalize with user block
+        user_block = make_user_block()
+        tracker.handle_event("sess-1", AddBlock(block=user_block))
+
+        # New assistant block should start new turn
+        block2 = make_assistant_block(block_id="a2", text="Second turn")
+        action = tracker.handle_event("sess-1", AddBlock(block=block2))
+
+        assert isinstance(action, SendNewMessage)
+        assert action.turn_id == "turn-a2"
+        assert "Second turn" in action.content
+        assert "First turn" not in action.content
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - TOOL_CALL Block Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleToolCallBlock:
+    """Tests for TOOL_CALL block handling."""
+
+    def test_tool_call_starts_turn_if_none(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test TOOL_CALL block starts a turn if none exists."""
+        block = make_tool_call_block(tool_name="Read", label="test.py")
+        action = tracker.handle_event("sess-1", AddBlock(block=block))
+
+        assert isinstance(action, SendNewMessage)
+        assert action.message_type == "turn"
+        assert "📖" in action.content  # Read icon
+        assert "test.py" in action.content
+
+    def test_tool_call_added_to_existing_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test TOOL_CALL block is added to existing turn."""
+        # Start turn with assistant
+        assistant_block = make_assistant_block(text="Let me check")
+        action1 = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        # Add tool call
+        tool_block = make_tool_call_block(tool_name="Read", label="test.py")
+        action2 = tracker.handle_event("sess-1", AddBlock(block=tool_block))
+
+        assert isinstance(action2, UpdateExistingMessage)
+        assert "Let me check" in action2.content
+        assert "📖" in action2.content
+        assert "test.py" in action2.content
+
+    def test_tool_call_with_result(self, tracker: MessageStateTracker) -> None:
+        """Test TOOL_CALL block with result."""
+        block = make_tool_call_block(
+            tool_name="Read", label="test.py", result="file contents here"
+        )
+        action = tracker.handle_event("sess-1", AddBlock(block=block))
+
+        assert isinstance(action, SendNewMessage)
+        assert "file contents here" in action.content
+
+    def test_tool_call_with_error(self, tracker: MessageStateTracker) -> None:
+        """Test TOOL_CALL block with error."""
+        block = make_tool_call_block(
+            tool_name="Read", label="test.py", is_error=True
+        )
+        action = tracker.handle_event("sess-1", AddBlock(block=block))
+
+        assert isinstance(action, SendNewMessage)
+        assert "Error" in action.content
+
+    def test_multiple_tool_calls_in_turn(self, tracker: MessageStateTracker) -> None:
+        """Test multiple tool calls in the same turn."""
+        # Start with assistant
+        assistant_block = make_assistant_block(text="Checking files")
+        action1 = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        # Add first tool
+        tool1 = make_tool_call_block(
+            block_id="t1", tool_name="Read", tool_use_id="tu1", label="file1.py"
+        )
+        tracker.handle_event("sess-1", AddBlock(block=tool1))
+
+        # Add second tool
+        tool2 = make_tool_call_block(
+            block_id="t2", tool_name="Bash", tool_use_id="tu2", label="ls -la"
+        )
+        action3 = tracker.handle_event("sess-1", AddBlock(block=tool2))
+
+        assert isinstance(action3, UpdateExistingMessage)
+        assert "file1.py" in action3.content
+        assert "ls -la" in action3.content
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - DURATION Block Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDurationBlock:
+    """Tests for DURATION block handling."""
+
+    def test_duration_block_added_to_turn(self, tracker: MessageStateTracker) -> None:
+        """Test DURATION block is added to current turn."""
+        # Start turn
+        assistant_block = make_assistant_block(text="Done!")
+        action1 = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        # Add duration
+        duration_block = make_duration_block(duration_ms=12300)
+        action2 = tracker.handle_event("sess-1", AddBlock(block=duration_block))
+
+        assert isinstance(action2, UpdateExistingMessage)
+        assert "12.3s" in action2.content
+
+    def test_duration_block_without_turn(self, tracker: MessageStateTracker) -> None:
+        """Test DURATION block without current turn returns NoAction."""
+        duration_block = make_duration_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=duration_block))
+
+        assert isinstance(action, NoAction)
+        assert "Duration without turn" in action.reason
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - SYSTEM Block Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleSystemBlock:
+    """Tests for SYSTEM block handling."""
+
+    def test_system_block_sends_new_message(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test SYSTEM block creates SendNewMessage."""
+        block = make_system_block(text="Session started")
+        action = tracker.handle_event("sess-1", AddBlock(block=block))
+
+        assert isinstance(action, SendNewMessage)
+        assert action.message_type == "system"
+        assert action.turn_id == "system-s1"
+        assert "Session started" in action.content
+        assert "⚡" in action.content
+
+    def test_system_block_does_not_affect_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test SYSTEM block does not affect current turn."""
+        # Start turn
+        assistant_block = make_assistant_block(text="Working...")
+        tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        state = tracker.get_session_state("sess-1")
+        turn = state.current_turn
+
+        # System block should not change the turn
+        system_block = make_system_block(text="Note")
+        tracker.handle_event("sess-1", AddBlock(block=system_block))
+
+        assert state.current_turn is turn
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - UpdateBlock Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleUpdateBlock:
+    """Tests for UpdateBlock handling."""
+
+    def test_update_block_updates_tool_result(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test UpdateBlock updates tool result in turn."""
+        # Start turn with tool call
+        tool_block = make_tool_call_block(
+            tool_name="Read", tool_use_id="tu1", label="test.py"
+        )
+        action1 = tracker.handle_event("sess-1", AddBlock(block=tool_block))
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        # Update with result
+        update = UpdateBlock(
+            block_id="t1",
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tu1",
+                label="test.py",
+                result="file contents",
+                is_error=False,
+            ),
+        )
+        action2 = tracker.handle_event("sess-1", update)
+
+        assert isinstance(action2, UpdateExistingMessage)
+        assert "file contents" in action2.content
+
+    def test_update_block_updates_tool_error(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test UpdateBlock updates tool error status."""
+        # Start turn with tool call
+        tool_block = make_tool_call_block(
+            tool_name="Bash", tool_use_id="tu1", label="ls -la"
+        )
+        action1 = tracker.handle_event("sess-1", AddBlock(block=tool_block))
+        tracker.record_message_id("sess-1", action1.turn_id, "telegram", "123", 456)
+
+        # Update with error
+        update = UpdateBlock(
+            block_id="t1",
+            content=ToolCallContent(
+                tool_name="Bash",
+                tool_use_id="tu1",
+                label="ls -la",
+                result=None,
+                is_error=True,
+            ),
+        )
+        action2 = tracker.handle_event("sess-1", update)
+
+        assert isinstance(action2, UpdateExistingMessage)
+        assert "Error" in action2.content
+
+    def test_update_block_without_turn(self, tracker: MessageStateTracker) -> None:
+        """Test UpdateBlock without current turn returns NoAction."""
+        update = UpdateBlock(
+            block_id="t1",
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tu1",
+                label="test.py",
+                result="result",
+            ),
+        )
+        action = tracker.handle_event("sess-1", update)
+
+        assert isinstance(action, NoAction)
+        assert "Update without current turn" in action.reason
+
+    def test_update_block_unknown_tool_use_id(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test UpdateBlock with unknown tool_use_id returns NoAction."""
+        # Start turn with tool call
+        tool_block = make_tool_call_block(
+            tool_name="Read", tool_use_id="tu1", label="test.py"
+        )
+        tracker.handle_event("sess-1", AddBlock(block=tool_block))
+
+        # Update with different tool_use_id
+        update = UpdateBlock(
+            block_id="t2",
+            content=ToolCallContent(
+                tool_name="Read",
+                tool_use_id="tu-unknown",
+                label="other.py",
+                result="result",
+            ),
+        )
+        action = tracker.handle_event("sess-1", update)
+
+        assert isinstance(action, NoAction)
+        assert "unknown block" in action.reason
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - ClearAll Handling
+# ---------------------------------------------------------------------------
+
+
+class TestHandleClearAll:
+    """Tests for ClearAll handling."""
+
+    def test_clear_all_sends_compaction_message(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test ClearAll creates SendNewMessage for compaction."""
+        action = tracker.handle_event("sess-1", ClearAll())
+
+        assert isinstance(action, SendNewMessage)
+        assert action.message_type == "system"
+        assert action.turn_id.startswith("clear-")
+        assert "Context compacted" in action.content
+        assert action.text_fallback == "Context compacted"
+
+    def test_clear_all_finalizes_current_turn(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test ClearAll finalizes the current turn."""
+        # Start turn
+        assistant_block = make_assistant_block(text="Working...")
+        tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        state = tracker.get_session_state("sess-1")
+        assert state.current_turn is not None
+        assert not state.current_turn.finalized
+
+        # Clear all
+        tracker.handle_event("sess-1", ClearAll())
+
+        # Current turn should be None now
+        assert state.current_turn is None
+
+    def test_clear_all_without_turn(self, tracker: MessageStateTracker) -> None:
+        """Test ClearAll without current turn still sends message."""
+        action = tracker.handle_event("sess-1", ClearAll())
+
+        assert isinstance(action, SendNewMessage)
+        assert "Context compacted" in action.content
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - Message ID Tracking
+# ---------------------------------------------------------------------------
+
+
+class TestMessageIdTracking:
+    """Tests for message ID tracking."""
+
+    def test_record_telegram_message_id(self, tracker: MessageStateTracker) -> None:
+        """Test recording Telegram message ID."""
+        # Start turn
+        assistant_block = make_assistant_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        # Record message ID
+        tracker.record_message_id(
+            "sess-1", action.turn_id, "telegram", "12345", 67890
+        )
+
+        # Verify
+        msg_id = tracker.get_message_id(
+            "sess-1", action.turn_id, "telegram", "12345"
+        )
+        assert msg_id == 67890
+
+    def test_record_slack_message_id(self, tracker: MessageStateTracker) -> None:
+        """Test recording Slack message ID."""
+        # Start turn
+        assistant_block = make_assistant_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        # Record message ID
+        tracker.record_message_id(
+            "sess-1", action.turn_id, "slack", "C12345", "ts123.456"
+        )
+
+        # Verify
+        msg_id = tracker.get_message_id(
+            "sess-1", action.turn_id, "slack", "C12345"
+        )
+        assert msg_id == "ts123.456"
+
+    def test_get_message_id_wrong_turn(self, tracker: MessageStateTracker) -> None:
+        """Test getting message ID for wrong turn returns None."""
+        # Start turn
+        assistant_block = make_assistant_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        tracker.record_message_id(
+            "sess-1", action.turn_id, "telegram", "12345", 67890
+        )
+
+        # Try to get with wrong turn_id
+        msg_id = tracker.get_message_id(
+            "sess-1", "wrong-turn", "telegram", "12345"
+        )
+        assert msg_id is None
+
+    def test_get_message_id_wrong_identifier(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test getting message ID for wrong identifier returns None."""
+        # Start turn
+        assistant_block = make_assistant_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+
+        tracker.record_message_id(
+            "sess-1", action.turn_id, "telegram", "12345", 67890
+        )
+
+        # Try to get with wrong identifier
+        msg_id = tracker.get_message_id(
+            "sess-1", action.turn_id, "telegram", "99999"
+        )
+        assert msg_id is None
+
+    def test_message_id_enables_update_action(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test that recording message ID makes next action an update."""
+        # Start turn
+        assistant_block = make_assistant_block(block_id="a1", text="First")
+        action1 = tracker.handle_event("sess-1", AddBlock(block=assistant_block))
+        assert isinstance(action1, SendNewMessage)
+
+        # Record message ID
+        tracker.record_message_id(
+            "sess-1", action1.turn_id, "telegram", "12345", 67890
+        )
+
+        # Next block should trigger update
+        tool_block = make_tool_call_block()
+        action2 = tracker.handle_event("sess-1", AddBlock(block=tool_block))
+        assert isinstance(action2, UpdateExistingMessage)
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - Replay Rendering
+# ---------------------------------------------------------------------------
+
+
+class TestReplayRendering:
+    """Tests for replay rendering."""
+
+    def test_render_replay_empty_events(self, tracker: MessageStateTracker) -> None:
+        """Test render_replay with empty events list."""
+        text, blocks = tracker.render_replay("sess-1", [])
+        assert text == ""
+        assert blocks == []
+
+    def test_render_replay_with_events(self, tracker: MessageStateTracker) -> None:
+        """Test render_replay with various events."""
+        events = [
+            AddBlock(block=make_user_block(block_id="u1", text="Hello")),
+            AddBlock(block=make_assistant_block(block_id="a1", text="Hi")),
+            AddBlock(block=make_tool_call_block(block_id="t1")),
+            AddBlock(block=make_tool_call_block(block_id="t2")),
+        ]
+
+        text, blocks = tracker.render_replay("sess-1", events)
+
+        assert "Catching up" in text
+        assert "(4 events)" in text
+        assert "User messages: 1" in text
+        assert "Assistant turns: 1" in text
+        assert "Tool calls: 2" in text
+
+        assert len(blocks) >= 1
+        assert "Catching up" in blocks[0]["text"]["text"]
+
+    def test_render_replay_only_user_messages(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test render_replay with only user messages."""
+        events = [
+            AddBlock(block=make_user_block(block_id="u1", text="Hello")),
+            AddBlock(block=make_user_block(block_id="u2", text="World")),
+        ]
+
+        text, blocks = tracker.render_replay("sess-1", events)
+
+        assert "User messages: 2" in text
+        assert "Assistant turns" not in text
+        assert "Tool calls" not in text
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - Other Block Types
+# ---------------------------------------------------------------------------
+
+
+class TestOtherBlockTypes:
+    """Tests for other block types."""
+
+    def test_thinking_block_returns_no_action(
+        self, tracker: MessageStateTracker
+    ) -> None:
+        """Test THINKING block returns NoAction."""
+        block = make_thinking_block()
+        action = tracker.handle_event("sess-1", AddBlock(block=block))
+
+        assert isinstance(action, NoAction)
+        assert "Thinking blocks" in action.reason
+
+
+# ---------------------------------------------------------------------------
+# Test MessageStateTracker - Turn Grouping Integration
+# ---------------------------------------------------------------------------
+
+
+class TestTurnGroupingIntegration:
+    """Integration tests for turn grouping."""
+
+    def test_full_turn_cycle(self, tracker: MessageStateTracker) -> None:
+        """Test a complete turn cycle: user -> assistant -> tools -> duration -> user."""
+        session = "sess-1"
+
+        # User message
+        action1 = tracker.handle_event(
+            session, AddBlock(block=make_user_block(text="Do something"))
+        )
+        assert isinstance(action1, SendNewMessage)
+        assert action1.message_type == "user"
+
+        # Assistant response
+        action2 = tracker.handle_event(
+            session, AddBlock(block=make_assistant_block(text="I'll help"))
+        )
+        assert isinstance(action2, SendNewMessage)
+        assert action2.message_type == "turn"
+        turn_id = action2.turn_id
+
+        # Record message IDs
+        tracker.record_message_id(session, turn_id, "telegram", "123", 456)
+        tracker.record_message_id(session, turn_id, "slack", "C123", "ts123")
+
+        # Tool call
+        action3 = tracker.handle_event(
+            session, AddBlock(block=make_tool_call_block(tool_name="Read", label="f.py"))
+        )
+        assert isinstance(action3, UpdateExistingMessage)
+        assert action3.turn_id == turn_id
+
+        # Duration
+        action4 = tracker.handle_event(
+            session, AddBlock(block=make_duration_block(duration_ms=5000))
+        )
+        assert isinstance(action4, UpdateExistingMessage)
+        assert "5.0s" in action4.content
+
+        # Next user message
+        action5 = tracker.handle_event(
+            session, AddBlock(block=make_user_block(block_id="u2", text="Thanks"))
+        )
+        assert isinstance(action5, SendNewMessage)
+        assert action5.message_type == "user"
+
+        # Verify turn was finalized
+        state = tracker.get_session_state(session)
+        # Current turn should be the old finalized one, not None
+        # (only cleared on ClearAll)
+        assert state.current_turn.finalized
+
+    def test_multiple_sessions_isolated(self, tracker: MessageStateTracker) -> None:
+        """Test that multiple sessions are isolated."""
+        # Session 1: start turn
+        tracker.handle_event(
+            "sess-1", AddBlock(block=make_assistant_block(text="Session 1"))
+        )
+
+        # Session 2: start different turn
+        tracker.handle_event(
+            "sess-2", AddBlock(block=make_assistant_block(text="Session 2"))
+        )
+
+        state1 = tracker.get_session_state("sess-1")
+        state2 = tracker.get_session_state("sess-2")
+
+        assert state1.current_turn.assistant_text == "Session 1"
+        assert state2.current_turn.assistant_text == "Session 2"
+
+
+# ---------------------------------------------------------------------------
+# Test Module Imports
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    """Tests for module imports."""
+
+    def test_import_from_message_state(self) -> None:
+        """Test imports from message_state module."""
+        from claude_session_player.watcher.message_state import (
+            MessageAction,
+            MessageStateTracker,
+            NoAction,
+            SendNewMessage,
+            SessionMessageState,
+            TurnState,
+            UpdateExistingMessage,
+        )
+
+        assert MessageAction is not None
+        assert MessageStateTracker is not None
+        assert NoAction is not None
+        assert SendNewMessage is not None
+        assert SessionMessageState is not None
+        assert TurnState is not None
+        assert UpdateExistingMessage is not None
+
+    def test_import_from_watcher_init(self) -> None:
+        """Test imports from watcher __init__."""
+        from claude_session_player.watcher import (
+            MessageAction,
+            MessageStateTracker,
+            NoAction,
+            SendNewMessage,
+            SessionMessageState,
+            TurnState,
+            UpdateExistingMessage,
+        )
+
+        assert MessageAction is not None
+        assert MessageStateTracker is not None
+        assert NoAction is not None
+        assert SendNewMessage is not None
+        assert SessionMessageState is not None
+        assert TurnState is not None
+        assert UpdateExistingMessage is not None
+
+    def test_all_exports(self) -> None:
+        """Test that all exports are in __all__."""
+        from claude_session_player.watcher import __all__
+
+        expected = [
+            "MessageAction",
+            "MessageStateTracker",
+            "NoAction",
+            "SendNewMessage",
+            "SessionMessageState",
+            "TurnState",
+            "UpdateExistingMessage",
+        ]
+        for name in expected:
+            assert name in __all__, f"{name} not in __all__"


### PR DESCRIPTION
## Summary

- Add `MessageStateTracker` class for tracking message state across Telegram and Slack destinations
- Implement turn-based grouping of events into messages
- Track message IDs per destination for message updates

## Changes

### New Files
- `claude_session_player/watcher/message_state.py` - MessageStateTracker and related dataclasses
- `tests/watcher/test_message_state.py` - 47 unit tests

### Modified Files
- `claude_session_player/watcher/__init__.py` - Export new classes

## Turn Grouping Rules

| Event | Action |
|-------|--------|
| USER | SendNewMessage + finalize previous turn |
| ASSISTANT | SendNewMessage or UpdateExistingMessage |
| TOOL_CALL | Add to current turn |
| DURATION | Add footer to current turn |
| SYSTEM | SendNewMessage (standalone) |
| ClearAll | SendNewMessage (context compacted) |

## Test Plan

- [x] Turn grouping: assistant + tools + duration in one turn
- [x] Turn finalization on USER
- [x] Multiple consecutive ASSISTANT blocks in one turn
- [x] UpdateBlock handling for tool results
- [x] ClearAll handling
- [x] Message ID tracking
- [x] Replay rendering

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)