### PR TITLE
Issue #76: Integrate messaging components into WatcherService

### DIFF
--- a/claude_session_player/watcher/service.py
+++ b/claude_session_player/watcher/service.py
@@ -9,6 +9,10 @@ This module provides the main orchestration service that wires together:
 - EventBufferManager: per-session event buffering
 - SSEManager: SSE event broadcasting
 - WatcherAPI: HTTP API endpoints
+- TelegramPublisher: Telegram Bot API integration
+- SlackPublisher: Slack Web API integration
+- MessageStateTracker: turn-based message grouping
+- MessageDebouncer: rate-limiting message updates
 """
 
 from __future__ import annotations
@@ -21,14 +25,23 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
-from claude_session_player.events import ProcessingContext
+from claude_session_player.events import Event, ProcessingContext
 from claude_session_player.watcher.api import WatcherAPI
 from claude_session_player.watcher.config import ConfigManager
-from claude_session_player.watcher.destinations import DestinationManager
+from claude_session_player.watcher.debouncer import MessageDebouncer
+from claude_session_player.watcher.destinations import AttachedDestination, DestinationManager
 from claude_session_player.watcher.event_buffer import EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher
+from claude_session_player.watcher.message_state import (
+    MessageStateTracker,
+    NoAction,
+    SendNewMessage,
+    UpdateExistingMessage,
+)
+from claude_session_player.watcher.slack_publisher import SlackError, SlackPublisher
 from claude_session_player.watcher.sse import SSEManager
 from claude_session_player.watcher.state import SessionState, StateManager
+from claude_session_player.watcher.telegram_publisher import TelegramError, TelegramPublisher
 from claude_session_player.watcher.transformer import transform
 
 if TYPE_CHECKING:
@@ -42,7 +55,8 @@ class WatcherService:
     """Main service orchestrating all watcher components.
 
     Handles lifecycle management (startup, shutdown) and event flow coordination
-    between file watcher, transformer, event buffer, and SSE manager.
+    between file watcher, transformer, event buffer, SSE manager, and messaging
+    publishers (Telegram, Slack).
     """
 
     config_path: Path
@@ -56,6 +70,12 @@ class WatcherService:
     event_buffer: EventBufferManager | None = None
     sse_manager: SSEManager | None = None
     api: WatcherAPI | None = None
+
+    # Messaging components (optional, created based on bot config)
+    telegram_publisher: TelegramPublisher | None = None
+    slack_publisher: SlackPublisher | None = None
+    message_state: MessageStateTracker | None = None
+    message_debouncer: MessageDebouncer | None = None
 
     # HTTP server config
     host: str = "127.0.0.1"
@@ -94,12 +114,29 @@ class WatcherService:
                 _on_session_stop=self._on_destination_session_stop,
             )
 
+        # Initialize messaging components based on bot config
+        bot_config = self.config_manager.get_bot_config()
+
+        if self.telegram_publisher is None and bot_config.telegram_token:
+            self.telegram_publisher = TelegramPublisher(token=bot_config.telegram_token)
+
+        if self.slack_publisher is None and bot_config.slack_token:
+            self.slack_publisher = SlackPublisher(token=bot_config.slack_token)
+
+        # Always create message state and debouncer (they work without publishers)
+        if self.message_state is None:
+            self.message_state = MessageStateTracker()
+
+        if self.message_debouncer is None:
+            self.message_debouncer = MessageDebouncer()
+
         if self.api is None:
             self.api = WatcherAPI(
                 config_manager=self.config_manager,
                 destination_manager=self.destination_manager,
                 event_buffer=self.event_buffer,
                 sse_manager=self.sse_manager,
+                replay_callback=self.replay_to_destination,
             )
 
     @property
@@ -116,8 +153,9 @@ class WatcherService:
            - Load state (or create fresh if missing/corrupt)
            - Validate file exists (remove from config if not)
            - Add to FileWatcher with saved position
-        3. Start FileWatcher
-        4. Start HTTP server
+        3. Restore messaging destinations from config
+        4. Start FileWatcher
+        5. Start HTTP server
         """
         if self._running:
             logger.warning("Service already running")
@@ -127,6 +165,10 @@ class WatcherService:
 
         # Load existing config and resume sessions
         await self._load_and_resume_sessions()
+
+        # Restore messaging destinations from config
+        await self.destination_manager.restore_from_config()
+        logger.info("Messaging destinations restored from config")
 
         # Start file watcher
         await self.file_watcher.start()
@@ -147,11 +189,13 @@ class WatcherService:
 
         Shutdown sequence:
         1. Stop accepting new HTTP connections
-        2. Stop FileWatcher
-        3. Save all session states
-        4. Send session_ended to all SSE clients
-        5. Close all SSE connections
-        6. Exit
+        2. Flush pending message updates
+        3. Close messaging publishers
+        4. Stop FileWatcher
+        5. Save all session states
+        6. Send session_ended to all SSE clients
+        7. Close all SSE connections
+        8. Exit
         """
         if not self._running:
             return
@@ -168,6 +212,20 @@ class WatcherService:
             self._runner = None
 
         logger.info("HTTP server stopped")
+
+        # Flush pending message updates
+        if self.message_debouncer:
+            await self.message_debouncer.flush()
+            logger.info("Message debouncer flushed")
+
+        # Close messaging publishers
+        if self.telegram_publisher:
+            await self.telegram_publisher.close()
+            logger.info("Telegram publisher closed")
+
+        if self.slack_publisher:
+            await self.slack_publisher.close()
+            logger.info("Slack publisher closed")
 
         # Stop file watcher
         await self.file_watcher.stop()
@@ -354,6 +412,7 @@ class WatcherService:
         4. for event in events:
                EventBufferManager.add_event(session_id, event)
                SSEManager.broadcast(session_id, event_id, event)
+               Publish to messaging destinations
 
         Args:
             session_id: The session that changed.
@@ -391,10 +450,13 @@ class WatcherService:
         )
         self.state_manager.save(session_id, new_state)
 
-        # Buffer events and broadcast to SSE subscribers
+        # Buffer events and broadcast to SSE subscribers + messaging destinations
         for event in events:
             event_id = self.event_buffer.add_event(session_id, event)
             await self.sse_manager.broadcast(session_id, event_id, event)
+
+            # Publish to messaging destinations
+            await self._publish_to_messaging(session_id, event)
 
     async def _on_file_deleted(self, session_id: str) -> None:
         """Handle file deletion callback from FileWatcher.
@@ -459,6 +521,10 @@ class WatcherService:
         """
         logger.info(f"Stopping file watching for session: {session_id}")
 
+        # Clear message state for session
+        if self.message_state:
+            self.message_state.clear_session(session_id)
+
         # Emit session_ended event to SSE subscribers
         await self.sse_manager.close_session(session_id, reason="no_destinations")
 
@@ -472,3 +538,236 @@ class WatcherService:
         self.state_manager.delete(session_id)
 
         # Note: config is not removed - session info persists
+
+    # -------------------------------------------------------------------------
+    # Messaging Methods
+    # -------------------------------------------------------------------------
+
+    async def _publish_to_messaging(self, session_id: str, event: Event) -> None:
+        """Publish event to all attached messaging destinations.
+
+        Args:
+            session_id: The session identifier.
+            event: The event to publish.
+        """
+        if not self.destination_manager or not self.message_state:
+            return
+
+        destinations = self.destination_manager.get_destinations(session_id)
+        if not destinations:
+            return
+
+        # Determine action based on event
+        action = self.message_state.handle_event(session_id, event)
+
+        if isinstance(action, NoAction):
+            return
+
+        # Publish to each destination
+        for dest in destinations:
+            await self._publish_action_to_destination(session_id, dest, action)
+
+    async def _publish_action_to_destination(
+        self,
+        session_id: str,
+        destination: AttachedDestination,
+        action: SendNewMessage | UpdateExistingMessage,
+    ) -> None:
+        """Publish a message action to a single destination.
+
+        Args:
+            session_id: The session identifier.
+            destination: The destination to publish to.
+            action: The message action to perform.
+        """
+        if isinstance(action, SendNewMessage):
+            await self._send_new_message(session_id, destination, action)
+        elif isinstance(action, UpdateExistingMessage):
+            await self._update_message(session_id, destination, action)
+
+    async def _send_new_message(
+        self,
+        session_id: str,
+        destination: AttachedDestination,
+        action: SendNewMessage,
+    ) -> None:
+        """Send a new message to a destination.
+
+        Args:
+            session_id: The session identifier.
+            destination: The destination to send to.
+            action: The SendNewMessage action with content.
+        """
+        try:
+            if destination.type == "telegram" and self.telegram_publisher:
+                message_id = await self.telegram_publisher.send_message(
+                    chat_id=destination.identifier,
+                    text=action.content,
+                )
+                if self.message_state:
+                    self.message_state.record_message_id(
+                        session_id,
+                        action.turn_id,
+                        "telegram",
+                        destination.identifier,
+                        message_id,
+                    )
+
+            elif destination.type == "slack" and self.slack_publisher:
+                ts = await self.slack_publisher.send_message(
+                    channel=destination.identifier,
+                    text=action.text_fallback,
+                    blocks=action.blocks,
+                )
+                if self.message_state:
+                    self.message_state.record_message_id(
+                        session_id,
+                        action.turn_id,
+                        "slack",
+                        destination.identifier,
+                        ts,
+                    )
+
+        except (TelegramError, SlackError) as e:
+            logger.warning(f"Failed to send message to {destination}: {e}")
+
+    async def _update_message(
+        self,
+        session_id: str,
+        destination: AttachedDestination,
+        action: UpdateExistingMessage,
+    ) -> None:
+        """Update an existing message (debounced).
+
+        Args:
+            session_id: The session identifier.
+            destination: The destination to update.
+            action: The UpdateExistingMessage action with content.
+        """
+        if not self.message_state:
+            return
+
+        message_id = self.message_state.get_message_id(
+            session_id, action.turn_id, destination.type, destination.identifier
+        )
+
+        if not message_id:
+            # No existing message, send new instead
+            # (This can happen after restart)
+            await self._send_new_message(
+                session_id,
+                destination,
+                SendNewMessage(
+                    turn_id=action.turn_id,
+                    message_type="turn",
+                    content=action.content,
+                    blocks=action.blocks,
+                    text_fallback=action.text_fallback,
+                ),
+            )
+            return
+
+        # Schedule debounced update
+        async def do_update() -> None:
+            try:
+                if destination.type == "telegram" and self.telegram_publisher:
+                    await self.telegram_publisher.edit_message(
+                        chat_id=destination.identifier,
+                        message_id=int(message_id),
+                        text=action.content,
+                    )
+                elif destination.type == "slack" and self.slack_publisher:
+                    await self.slack_publisher.update_message(
+                        channel=destination.identifier,
+                        ts=str(message_id),
+                        text=action.text_fallback,
+                        blocks=action.blocks,
+                    )
+            except (TelegramError, SlackError) as e:
+                logger.warning(f"Failed to update message: {e}")
+
+        if self.message_debouncer:
+            await self.message_debouncer.schedule_update(
+                destination_type=destination.type,
+                identifier=destination.identifier,
+                message_id=str(message_id),
+                update_fn=do_update,
+                content=action,
+            )
+
+    async def replay_to_destination(
+        self,
+        session_id: str,
+        destination_type: str,
+        identifier: str,
+        count: int,
+    ) -> int:
+        """Replay recent events to a newly attached destination.
+
+        Args:
+            session_id: The session identifier.
+            destination_type: "telegram" or "slack".
+            identifier: chat_id for Telegram, channel for Slack.
+            count: Number of events to replay.
+
+        Returns:
+            Number of events replayed.
+        """
+        buffer = self.event_buffer.get_buffer(session_id)
+        events = buffer.get_since(None)
+
+        # Limit to requested count (take last N)
+        events_to_replay = events[-count:] if len(events) > count else events
+
+        if not events_to_replay or not self.message_state:
+            return 0
+
+        # Render as batched catch-up message
+        event_list = [e for _, e in events_to_replay]
+        content, blocks = self.message_state.render_replay(session_id, event_list)
+
+        if not content:
+            return 0
+
+        # Send catch-up message
+        try:
+            if destination_type == "telegram" and self.telegram_publisher:
+                await self.telegram_publisher.send_message(
+                    chat_id=identifier,
+                    text=content,
+                )
+            elif destination_type == "slack" and self.slack_publisher:
+                await self.slack_publisher.send_message(
+                    channel=identifier,
+                    text=f"Catching up ({len(events_to_replay)} events)",
+                    blocks=blocks,
+                )
+        except (TelegramError, SlackError) as e:
+            logger.warning(f"Failed to send replay: {e}")
+            return 0
+
+        return len(events_to_replay)
+
+    async def validate_destination(self, destination_type: str) -> None:
+        """Validate bot credentials for a destination type.
+
+        Args:
+            destination_type: "telegram" or "slack".
+
+        Raises:
+            TelegramError: If Telegram validation fails.
+            SlackError: If Slack validation fails.
+            ValueError: If destination type not configured.
+        """
+        from claude_session_player.watcher.telegram_publisher import TelegramAuthError
+        from claude_session_player.watcher.slack_publisher import SlackAuthError
+
+        if destination_type == "telegram":
+            if not self.telegram_publisher:
+                raise TelegramAuthError("Telegram bot token not configured")
+            await self.telegram_publisher.validate()
+
+        elif destination_type == "slack":
+            if not self.slack_publisher:
+                raise SlackAuthError("Slack bot token not configured")
+            await self.slack_publisher.validate()

--- a/issues/worklogs/76-worklog.md
+++ b/issues/worklogs/76-worklog.md
@@ -1,0 +1,125 @@
+# Issue #76: Integrate messaging components into WatcherService
+
+## Summary
+
+Integrated all messaging components (TelegramPublisher, SlackPublisher, MessageStateTracker, MessageDebouncer, DestinationManager) into the WatcherService for end-to-end Telegram and Slack notifications.
+
+## Changes Made
+
+### Modified Files
+
+1. **`claude_session_player/watcher/service.py`**
+   - Added imports for all messaging components:
+     - `MessageDebouncer`, `AttachedDestination`, `DestinationManager`
+     - `MessageStateTracker`, `NoAction`, `SendNewMessage`, `UpdateExistingMessage`
+     - `TelegramError`, `TelegramPublisher`, `SlackError`, `SlackPublisher`
+   - Added new dataclass fields:
+     - `telegram_publisher: TelegramPublisher | None`
+     - `slack_publisher: SlackPublisher | None`
+     - `message_state: MessageStateTracker | None`
+     - `message_debouncer: MessageDebouncer | None`
+   - Updated `__post_init__()`:
+     - Creates TelegramPublisher if telegram token configured in bot_config
+     - Creates SlackPublisher if slack token configured in bot_config
+     - Always creates MessageStateTracker and MessageDebouncer
+     - Injects replay_callback into WatcherAPI
+   - Updated `start()`:
+     - Restores messaging destinations from config on startup
+   - Updated `stop()`:
+     - Flushes pending debounced updates
+     - Closes Telegram and Slack publishers
+   - Updated `_on_file_change()`:
+     - Publishes events to messaging destinations after SSE broadcast
+   - Updated `_on_destination_session_stop()`:
+     - Clears message state when session stops
+   - Added new messaging methods:
+     - `_publish_to_messaging()`: Dispatches events to MessageStateTracker
+     - `_publish_action_to_destination()`: Routes actions to send/update
+     - `_send_new_message()`: Sends new messages to Telegram/Slack
+     - `_update_message()`: Schedules debounced message updates
+     - `replay_to_destination()`: Sends batched catch-up messages
+     - `validate_destination()`: Validates bot credentials on demand
+
+2. **`claude_session_player/watcher/api.py`**
+   - Added `ReplayCallback` type alias
+   - Added `replay_callback: ReplayCallback | None` field to WatcherAPI
+   - Updated `_replay_to_destination()` to use injected callback
+
+### New Files
+
+1. **`tests/watcher/test_messaging_integration.py`**
+   - 21 integration tests covering:
+     - Service initialization with messaging components
+     - Event flow to Telegram/Slack destinations
+     - Turn grouping (assistant + tools in one message)
+     - Message update debouncing
+     - Replay functionality
+     - Graceful shutdown (flush debouncer, close publishers)
+     - Error handling (failures logged, not raised)
+     - ClearAll (context compaction) handling
+     - Multiple destinations (same type and mixed)
+     - Service startup with restored destinations
+
+## Design Decisions
+
+### Callback Injection for Replay
+
+The WatcherAPI doesn't have direct access to WatcherService (to avoid circular dependencies). Instead of adding the service as a dependency, a `replay_callback` is injected that delegates to `service.replay_to_destination()`. This maintains clean separation of concerns.
+
+### Lazy Publisher Creation
+
+Publishers are only created if their token is configured in `bot_config`. This allows the service to run without any messaging configured (graceful degradation).
+
+### Message State Clearing on Session Stop
+
+When a session stops (no more destinations), message state is cleared. This ensures we don't accumulate stale turn state for sessions that are no longer active.
+
+### Error Handling Strategy
+
+Messaging failures are logged as warnings but don't raise exceptions. This prevents a single failed destination from blocking delivery to other destinations or disrupting SSE streaming.
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestServiceMessagingInitialization | 6 | component creation |
+| TestEventFlowToMessaging | 5 | user/assistant blocks, turn grouping, debouncing |
+| TestReplayToDestination | 2 | replay with/without events |
+| TestMessagingShutdown | 2 | flush debouncer, close publishers |
+| TestMessagingErrorHandling | 2 | failures logged, validation |
+| TestClearAllEvent | 1 | context compaction |
+| TestMultipleDestinations | 2 | all destinations, multiple chats |
+| TestServiceStartWithDestinations | 1 | restore from config |
+
+## Test Results
+
+- **Before:** 1097 tests
+- **After:** 1119 tests (21 new + 1 from prior pass)
+- All tests pass
+
+## Acceptance Criteria Status
+
+- [x] WatcherService imports and initializes all messaging components
+- [x] Publishers created based on bot config (lazy, only if token present)
+- [x] `_on_file_change` publishes to messaging destinations
+- [x] New messages sent immediately
+- [x] Message updates debounced
+- [x] Message IDs tracked in MessageStateTracker
+- [x] `replay_to_destination()` sends batched catch-up message
+- [x] `validate_destination()` validates credentials on demand
+- [x] Graceful shutdown flushes pending updates and closes publishers
+- [x] Integration tests:
+  - [x] End-to-end: file change → Telegram message (mocked)
+  - [x] End-to-end: file change → Slack message (mocked)
+  - [x] Turn grouping in messages
+  - [x] Message updates debounced
+  - [x] Replay on attach
+  - [x] Credentials validated on first attach
+- [x] Service starts without messaging deps (graceful degradation)
+
+## Spec Reference
+
+Implements issue #76 from `.claude/specs/messaging-integration.md`:
+- Main integration point connecting all messaging components
+- End-to-end event flow from FileWatcher to Telegram/Slack
+- Proper shutdown sequence with flush and close

--- a/tests/watcher/test_messaging_integration.py
+++ b/tests/watcher/test_messaging_integration.py
@@ -1,0 +1,944 @@
+"""Integration tests for messaging components in WatcherService.
+
+Tests the end-to-end flow from file changes to Telegram/Slack message delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_session_player.events import (
+    AddBlock,
+    AssistantContent,
+    Block,
+    BlockType,
+    ClearAll,
+    DurationContent,
+    ProcessingContext,
+    ToolCallContent,
+    UpdateBlock,
+    UserContent,
+)
+from claude_session_player.watcher.config import BotConfig, ConfigManager
+from claude_session_player.watcher.debouncer import MessageDebouncer
+from claude_session_player.watcher.destinations import DestinationManager
+from claude_session_player.watcher.event_buffer import EventBufferManager
+from claude_session_player.watcher.file_watcher import FileWatcher
+from claude_session_player.watcher.message_state import (
+    MessageStateTracker,
+    NoAction,
+    SendNewMessage,
+    UpdateExistingMessage,
+)
+from claude_session_player.watcher.service import WatcherService
+from claude_session_player.watcher.slack_publisher import SlackError, SlackPublisher
+from claude_session_player.watcher.sse import SSEManager
+from claude_session_player.watcher.state import StateManager
+from claude_session_player.watcher.telegram_publisher import TelegramError, TelegramPublisher
+
+
+# --- Mock Publishers ---
+
+
+@dataclass
+class MockTelegramPublisher:
+    """Mock TelegramPublisher for testing."""
+
+    token: str | None = None
+    validated: bool = False
+    sent_messages: list[dict] = field(default_factory=list)
+    edited_messages: list[dict] = field(default_factory=list)
+    _next_message_id: int = field(default=1, repr=False)
+    _should_fail: bool = field(default=False, repr=False)
+    _closed: bool = field(default=False, repr=False)
+
+    async def validate(self) -> None:
+        if self._should_fail:
+            raise TelegramError("Validation failed")
+        self.validated = True
+
+    async def send_message(
+        self, chat_id: str, text: str, parse_mode: str = "Markdown"
+    ) -> int:
+        if self._should_fail:
+            raise TelegramError("Send failed")
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        self.sent_messages.append({
+            "chat_id": chat_id,
+            "text": text,
+            "message_id": message_id,
+        })
+        return message_id
+
+    async def edit_message(
+        self, chat_id: str, message_id: int, text: str, parse_mode: str = "Markdown"
+    ) -> bool:
+        if self._should_fail:
+            raise TelegramError("Edit failed")
+        self.edited_messages.append({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": text,
+        })
+        return True
+
+    async def close(self) -> None:
+        self._closed = True
+
+
+@dataclass
+class MockSlackPublisher:
+    """Mock SlackPublisher for testing."""
+
+    token: str | None = None
+    validated: bool = False
+    sent_messages: list[dict] = field(default_factory=list)
+    updated_messages: list[dict] = field(default_factory=list)
+    _next_ts: int = field(default=1, repr=False)
+    _should_fail: bool = field(default=False, repr=False)
+    _closed: bool = field(default=False, repr=False)
+
+    async def validate(self) -> None:
+        if self._should_fail:
+            raise SlackError("Validation failed")
+        self.validated = True
+
+    async def send_message(
+        self, channel: str, text: str, blocks: list[dict] | None = None
+    ) -> str:
+        if self._should_fail:
+            raise SlackError("Send failed")
+        ts = f"1234567890.{self._next_ts:06d}"
+        self._next_ts += 1
+        self.sent_messages.append({
+            "channel": channel,
+            "text": text,
+            "blocks": blocks,
+            "ts": ts,
+        })
+        return ts
+
+    async def update_message(
+        self, channel: str, ts: str, text: str, blocks: list[dict] | None = None
+    ) -> bool:
+        if self._should_fail:
+            raise SlackError("Update failed")
+        self.updated_messages.append({
+            "channel": channel,
+            "ts": ts,
+            "text": text,
+            "blocks": blocks,
+        })
+        return True
+
+    async def close(self) -> None:
+        self._closed = True
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def temp_config_path(tmp_path: Path) -> Path:
+    """Create a temporary config file path."""
+    return tmp_path / "config.yaml"
+
+
+@pytest.fixture
+def temp_state_dir(tmp_path: Path) -> Path:
+    """Create a temporary state directory."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    return state_dir
+
+
+@pytest.fixture
+def session_file(tmp_path: Path) -> Path:
+    """Create a temporary session file."""
+    session_path = tmp_path / "session.jsonl"
+    session_path.write_text('{"type":"user","message":{"content":"hello"}}\n')
+    return session_path
+
+
+@pytest.fixture
+def mock_telegram_publisher() -> MockTelegramPublisher:
+    """Create a mock Telegram publisher."""
+    return MockTelegramPublisher(token="test-telegram-token")
+
+
+@pytest.fixture
+def mock_slack_publisher() -> MockSlackPublisher:
+    """Create a mock Slack publisher."""
+    return MockSlackPublisher(token="test-slack-token")
+
+
+@pytest.fixture
+def watcher_service_with_messaging(
+    temp_config_path: Path,
+    temp_state_dir: Path,
+    mock_telegram_publisher: MockTelegramPublisher,
+    mock_slack_publisher: MockSlackPublisher,
+) -> WatcherService:
+    """Create a WatcherService with mock messaging publishers."""
+    # Create config manager with bot tokens
+    config_manager = ConfigManager(temp_config_path)
+    # Mock the bot config
+    config_manager._bot_config = BotConfig(
+        telegram_token="test-telegram-token",
+        slack_token="test-slack-token",
+    )
+
+    service = WatcherService(
+        config_path=temp_config_path,
+        state_dir=temp_state_dir,
+        config_manager=config_manager,
+        telegram_publisher=mock_telegram_publisher,
+        slack_publisher=mock_slack_publisher,
+        port=8899,
+    )
+
+    return service
+
+
+# --- Tests for Service Initialization ---
+
+
+class TestServiceMessagingInitialization:
+    """Tests for messaging component initialization in WatcherService."""
+
+    def test_creates_message_state_tracker(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Service creates MessageStateTracker."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+        assert service.message_state is not None
+        assert isinstance(service.message_state, MessageStateTracker)
+
+    def test_creates_message_debouncer(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Service creates MessageDebouncer."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+        assert service.message_debouncer is not None
+        assert isinstance(service.message_debouncer, MessageDebouncer)
+
+    def test_creates_telegram_publisher_if_configured(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Service creates TelegramPublisher when token is configured."""
+        config_manager = ConfigManager(temp_config_path)
+        config_manager._bot_config = BotConfig(telegram_token="test-token")
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            config_manager=config_manager,
+        )
+
+        assert service.telegram_publisher is not None
+
+    def test_creates_slack_publisher_if_configured(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Service creates SlackPublisher when token is configured."""
+        config_manager = ConfigManager(temp_config_path)
+        config_manager._bot_config = BotConfig(slack_token="xoxb-test-token")
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            config_manager=config_manager,
+        )
+
+        assert service.slack_publisher is not None
+
+    def test_no_publishers_without_tokens(
+        self, temp_config_path: Path, temp_state_dir: Path
+    ) -> None:
+        """Service doesn't create publishers without tokens."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+        )
+
+        assert service.telegram_publisher is None
+        assert service.slack_publisher is None
+
+    def test_accepts_injected_publishers(
+        self,
+        temp_config_path: Path,
+        temp_state_dir: Path,
+        mock_telegram_publisher: MockTelegramPublisher,
+        mock_slack_publisher: MockSlackPublisher,
+    ) -> None:
+        """Service accepts injected publishers for testing."""
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            telegram_publisher=mock_telegram_publisher,
+            slack_publisher=mock_slack_publisher,
+        )
+
+        assert service.telegram_publisher is mock_telegram_publisher
+        assert service.slack_publisher is mock_slack_publisher
+
+
+# --- Tests for Event Flow to Messaging ---
+
+
+class TestEventFlowToMessaging:
+    """Tests for event flow from file changes to messaging destinations."""
+
+    async def test_user_block_sends_telegram_message(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """USER block sends new Telegram message."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach Telegram destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Simulate user message event
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello, Claude!"),
+            )
+            event = AddBlock(block=user_block)
+            await service._publish_to_messaging("test-session", event)
+
+            # Verify message was sent
+            assert len(publisher.sent_messages) == 1
+            msg = publisher.sent_messages[0]
+            assert msg["chat_id"] == "123456789"
+            assert "Hello" in msg["text"]
+
+        finally:
+            await service.stop()
+
+    async def test_assistant_block_sends_slack_message(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """ASSISTANT block sends new Slack message."""
+        service = watcher_service_with_messaging
+        publisher = service.slack_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach Slack destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="slack",
+                identifier="C0123456789",
+            )
+
+            # Simulate assistant message event
+            assistant_block = Block(
+                id="asst-1",
+                type=BlockType.ASSISTANT,
+                content=AssistantContent(text="Hello! How can I help?"),
+            )
+            event = AddBlock(block=assistant_block)
+            await service._publish_to_messaging("test-session", event)
+
+            # Verify message was sent
+            assert len(publisher.sent_messages) == 1
+            msg = publisher.sent_messages[0]
+            assert msg["channel"] == "C0123456789"
+
+        finally:
+            await service.stop()
+
+    async def test_no_message_without_destinations(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """No messages sent when no destinations attached."""
+        service = watcher_service_with_messaging
+        telegram_publisher = service.telegram_publisher
+        slack_publisher = service.slack_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Don't attach any destinations
+
+            # Simulate event
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello!"),
+            )
+            event = AddBlock(block=user_block)
+            await service._publish_to_messaging("test-session", event)
+
+            # Verify no messages sent
+            assert len(telegram_publisher.sent_messages) == 0
+            assert len(slack_publisher.sent_messages) == 0
+
+        finally:
+            await service.stop()
+
+    async def test_turn_grouping(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Multiple events in a turn produce update, not new messages."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach Telegram destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Send initial assistant message
+            assistant_block = Block(
+                id="asst-1",
+                type=BlockType.ASSISTANT,
+                content=AssistantContent(text="Let me help."),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=assistant_block)
+            )
+
+            # First message sent
+            assert len(publisher.sent_messages) == 1
+            message_id = publisher.sent_messages[0]["message_id"]
+
+            # Record message ID to enable updates
+            service.message_state.record_message_id(
+                "test-session",
+                f"turn-asst-1",
+                "telegram",
+                "123456789",
+                message_id,
+            )
+
+            # Add tool call to same turn
+            tool_block = Block(
+                id="tool-1",
+                type=BlockType.TOOL_CALL,
+                content=ToolCallContent(
+                    tool_name="Read",
+                    tool_use_id="tu-1",
+                    label="config.py",
+                ),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=tool_block)
+            )
+
+            # Should schedule update, not new message
+            # Wait for debouncer
+            await asyncio.sleep(0.6)
+
+            # Should have 1 sent and 1 edited
+            assert len(publisher.sent_messages) == 1
+            assert len(publisher.edited_messages) == 1
+            assert publisher.edited_messages[0]["message_id"] == message_id
+
+        finally:
+            await service.stop()
+
+    async def test_message_update_debounced(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Rapid updates are debounced."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach Telegram destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Send initial assistant message
+            assistant_block = Block(
+                id="asst-1",
+                type=BlockType.ASSISTANT,
+                content=AssistantContent(text="Let me help."),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=assistant_block)
+            )
+
+            message_id = publisher.sent_messages[0]["message_id"]
+            service.message_state.record_message_id(
+                "test-session",
+                f"turn-asst-1",
+                "telegram",
+                "123456789",
+                message_id,
+            )
+
+            # Rapidly add multiple tool calls
+            for i in range(5):
+                tool_block = Block(
+                    id=f"tool-{i}",
+                    type=BlockType.TOOL_CALL,
+                    content=ToolCallContent(
+                        tool_name="Read",
+                        tool_use_id=f"tu-{i}",
+                        label=f"file{i}.py",
+                    ),
+                )
+                await service._publish_to_messaging(
+                    "test-session", AddBlock(block=tool_block)
+                )
+
+            # Wait for debouncer (Telegram: 500ms)
+            await asyncio.sleep(0.6)
+
+            # Should have only 1 edit (last one wins)
+            assert len(publisher.edited_messages) == 1
+
+        finally:
+            await service.stop()
+
+
+# --- Tests for Replay ---
+
+
+class TestReplayToDestination:
+    """Tests for replay functionality."""
+
+    async def test_replay_sends_catch_up_message(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Replay sends batched catch-up message."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Add some events to buffer
+            for i in range(5):
+                user_block = Block(
+                    id=f"user-{i}",
+                    type=BlockType.USER,
+                    content=UserContent(text=f"Message {i}"),
+                )
+                service.event_buffer.add_event(
+                    "test-session", AddBlock(block=user_block)
+                )
+
+            # Replay to Telegram destination
+            replayed = await service.replay_to_destination(
+                session_id="test-session",
+                destination_type="telegram",
+                identifier="123456789",
+                count=3,
+            )
+
+            assert replayed == 3
+            assert len(publisher.sent_messages) == 1
+            assert "Catching up" in publisher.sent_messages[0]["text"]
+
+        finally:
+            await service.stop()
+
+    async def test_replay_returns_zero_when_no_events(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Replay returns 0 when no events in buffer."""
+        service = watcher_service_with_messaging
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            replayed = await service.replay_to_destination(
+                session_id="test-session",
+                destination_type="telegram",
+                identifier="123456789",
+                count=10,
+            )
+
+            assert replayed == 0
+
+        finally:
+            await service.stop()
+
+
+# --- Tests for Shutdown ---
+
+
+class TestMessagingShutdown:
+    """Tests for graceful shutdown of messaging components."""
+
+    async def test_shutdown_flushes_debouncer(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Shutdown flushes pending debounced updates."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach Telegram destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Send initial message
+            assistant_block = Block(
+                id="asst-1",
+                type=BlockType.ASSISTANT,
+                content=AssistantContent(text="Initial"),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=assistant_block)
+            )
+
+            message_id = publisher.sent_messages[0]["message_id"]
+            service.message_state.record_message_id(
+                "test-session",
+                f"turn-asst-1",
+                "telegram",
+                "123456789",
+                message_id,
+            )
+
+            # Schedule update (not yet delivered)
+            tool_block = Block(
+                id="tool-1",
+                type=BlockType.TOOL_CALL,
+                content=ToolCallContent(
+                    tool_name="Read",
+                    tool_use_id="tu-1",
+                    label="file.py",
+                ),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=tool_block)
+            )
+
+            # Before debounce timeout, edited_messages should be empty
+            assert len(publisher.edited_messages) == 0
+
+            # Stop should flush pending updates
+            await service.stop()
+
+            # After stop, update should be delivered
+            assert len(publisher.edited_messages) == 1
+
+        except Exception:
+            if service.is_running:
+                await service.stop()
+            raise
+
+    async def test_shutdown_closes_publishers(
+        self,
+        watcher_service_with_messaging: WatcherService,
+    ) -> None:
+        """Shutdown closes messaging publishers."""
+        service = watcher_service_with_messaging
+        telegram = service.telegram_publisher
+        slack = service.slack_publisher
+
+        await service.start()
+        await service.stop()
+
+        assert telegram._closed
+        assert slack._closed
+
+
+# --- Tests for Error Handling ---
+
+
+class TestMessagingErrorHandling:
+    """Tests for error handling in messaging operations."""
+
+    async def test_send_failure_logged_not_raised(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Send failures are logged but don't raise exceptions."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+        publisher._should_fail = True
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Send event (should fail but not raise)
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello!"),
+            )
+            # Should not raise
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=user_block)
+            )
+
+        finally:
+            await service.stop()
+
+    async def test_validates_destination_on_demand(
+        self,
+        watcher_service_with_messaging: WatcherService,
+    ) -> None:
+        """validate_destination validates bot credentials."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        await service.validate_destination("telegram")
+        assert publisher.validated
+
+
+# --- Tests for ClearAll Event ---
+
+
+class TestClearAllEvent:
+    """Tests for ClearAll (context compaction) handling."""
+
+    async def test_clear_all_sends_compaction_message(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """ClearAll sends context compaction message."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach destination
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+
+            # Send ClearAll event
+            await service._publish_to_messaging("test-session", ClearAll())
+
+            # Should send compaction message
+            assert len(publisher.sent_messages) == 1
+            assert "compacted" in publisher.sent_messages[0]["text"].lower()
+
+        finally:
+            await service.stop()
+
+
+# --- Tests for Multiple Destinations ---
+
+
+class TestMultipleDestinations:
+    """Tests for publishing to multiple destinations."""
+
+    async def test_sends_to_all_destinations(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Events are sent to all attached destinations."""
+        service = watcher_service_with_messaging
+        telegram = service.telegram_publisher
+        slack = service.slack_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach both Telegram and Slack
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="telegram",
+                identifier="123456789",
+            )
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_file,
+                destination_type="slack",
+                identifier="C0123456789",
+            )
+
+            # Send event
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello!"),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=user_block)
+            )
+
+            # Both should receive messages
+            assert len(telegram.sent_messages) == 1
+            assert len(slack.sent_messages) == 1
+
+        finally:
+            await service.stop()
+
+    async def test_sends_to_multiple_chats(
+        self,
+        watcher_service_with_messaging: WatcherService,
+        session_file: Path,
+    ) -> None:
+        """Events are sent to multiple chats of same type."""
+        service = watcher_service_with_messaging
+        publisher = service.telegram_publisher
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_file)
+
+            # Attach multiple Telegram chats
+            for chat_id in ["111", "222", "333"]:
+                await service.destination_manager.attach(
+                    session_id="test-session",
+                    path=session_file,
+                    destination_type="telegram",
+                    identifier=chat_id,
+                )
+
+            # Send event
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello!"),
+            )
+            await service._publish_to_messaging(
+                "test-session", AddBlock(block=user_block)
+            )
+
+            # All chats should receive messages
+            assert len(publisher.sent_messages) == 3
+            chat_ids = [m["chat_id"] for m in publisher.sent_messages]
+            assert set(chat_ids) == {"111", "222", "333"}
+
+        finally:
+            await service.stop()
+
+
+# --- Tests for Service Start with Destinations ---
+
+
+class TestServiceStartWithDestinations:
+    """Tests for service startup restoring destinations."""
+
+    async def test_start_restores_destinations(
+        self, temp_config_path: Path, temp_state_dir: Path, tmp_path: Path
+    ) -> None:
+        """Service startup restores destinations from config."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text('{"type":"user"}\n')
+
+        # Pre-populate config with destinations
+        import yaml
+
+        config_data = {
+            "bots": {
+                "telegram": {"token": "test-token"},
+            },
+            "sessions": {
+                "restored-session": {
+                    "path": str(session_file),
+                    "destinations": {
+                        "telegram": [{"chat_id": "123456"}],
+                    },
+                }
+            },
+        }
+        temp_config_path.write_text(yaml.dump(config_data))
+
+        mock_telegram = MockTelegramPublisher(token="test-token")
+
+        service = WatcherService(
+            config_path=temp_config_path,
+            state_dir=temp_state_dir,
+            telegram_publisher=mock_telegram,
+            port=8898,
+        )
+
+        try:
+            await service.start()
+
+            # Destinations should be restored
+            destinations = service.destination_manager.get_destinations("restored-session")
+            assert len(destinations) == 1
+            assert destinations[0].type == "telegram"
+            assert destinations[0].identifier == "123456"
+
+        finally:
+            await service.stop()


### PR DESCRIPTION
## Summary

- Wire together all messaging components for end-to-end Telegram and Slack notifications
- Add TelegramPublisher, SlackPublisher, MessageStateTracker, MessageDebouncer to WatcherService
- Implement event flow from file changes to messaging destinations
- Add replay functionality for batched catch-up messages
- Graceful shutdown with flush and close

## Test plan

- [x] Run `pytest tests/watcher/test_messaging_integration.py` - 21 new tests pass
- [x] Run `pytest` - all 1119 tests pass
- [x] Verify service starts without messaging tokens (graceful degradation)
- [x] Verify event flow: file change → Telegram message (mocked)
- [x] Verify event flow: file change → Slack message (mocked)
- [x] Verify turn grouping: assistant + tools in one message
- [x] Verify debouncing: rapid updates coalesced
- [x] Verify replay: batched catch-up message sent on attach
- [x] Verify shutdown: pending updates flushed, publishers closed

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)