### PR TITLE
Issue #88: Add SearchStateManager for pagination state

### DIFF
--- a/claude_session_player/watcher/search_state.py
+++ b/claude_session_player/watcher/search_state.py
@@ -1,0 +1,176 @@
+"""Search state manager for pagination state.
+
+This module provides:
+- SearchState: Stores an active search with results and pagination offset
+- SearchStateManager: Manages search state per chat with TTL expiration
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from .indexer import SessionInfo
+from .search import SearchFilters
+
+
+@dataclass
+class SearchState:
+    """State for an active search in a chat.
+
+    Stores the full result list and tracks pagination offset,
+    allowing pagination buttons to navigate without re-executing the search.
+    """
+
+    query: str
+    filters: SearchFilters
+    results: list[SessionInfo]
+    current_offset: int
+    message_id: int | str  # Slack ts or Telegram message_id
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def get_page(self, limit: int = 5) -> list[SessionInfo]:
+        """Get the current page of results.
+
+        Args:
+            limit: Maximum number of results per page.
+
+        Returns:
+            List of sessions for the current page.
+        """
+        return self.results[self.current_offset : self.current_offset + limit]
+
+    def session_at_index(self, index: int) -> SessionInfo | None:
+        """Get session by page-relative index (0-4).
+
+        Args:
+            index: The page-relative index (0-based).
+
+        Returns:
+            SessionInfo if index is valid, None otherwise.
+        """
+        actual_index = self.current_offset + index
+        if 0 <= actual_index < len(self.results):
+            return self.results[actual_index]
+        return None
+
+    def has_next_page(self, limit: int = 5) -> bool:
+        """Check if there are more results after the current page.
+
+        Args:
+            limit: Results per page.
+
+        Returns:
+            True if there are more results.
+        """
+        return self.current_offset + limit < len(self.results)
+
+    def has_prev_page(self) -> bool:
+        """Check if there are results before the current page.
+
+        Returns:
+            True if not on the first page.
+        """
+        return self.current_offset > 0
+
+
+class SearchStateManager:
+    """Manages search state for active searches.
+
+    Stores one search state per chat, with automatic TTL expiration.
+    Thread-safe for concurrent access.
+    """
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        """Initialize the manager.
+
+        Args:
+            ttl_seconds: Time-to-live for search states (default: 5 minutes).
+        """
+        self._states: dict[str, SearchState] = {}
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+
+    def save(self, chat_id: str, state: SearchState) -> None:
+        """Save or update search state for a chat.
+
+        A new search replaces any previous state for the same chat.
+        Also cleans up expired states from other chats.
+
+        Args:
+            chat_id: The chat identifier (e.g., "telegram:123456789").
+            state: The search state to save.
+        """
+        with self._lock:
+            self._states[chat_id] = state
+            self._cleanup_expired()
+
+    def get(self, chat_id: str) -> SearchState | None:
+        """Get search state for a chat.
+
+        Args:
+            chat_id: The chat identifier.
+
+        Returns:
+            SearchState if found and not expired, None otherwise.
+        """
+        with self._lock:
+            state = self._states.get(chat_id)
+            if state is None:
+                return None
+
+            # Check if expired
+            age = (datetime.now(timezone.utc) - state.created_at).total_seconds()
+            if age > self._ttl:
+                del self._states[chat_id]
+                return None
+
+            return state
+
+    def update_offset(self, chat_id: str, new_offset: int) -> SearchState | None:
+        """Update pagination offset for a chat's search state.
+
+        Args:
+            chat_id: The chat identifier.
+            new_offset: The new offset to set.
+
+        Returns:
+            Updated SearchState if found and not expired, None otherwise.
+        """
+        with self._lock:
+            state = self._states.get(chat_id)
+            if state is None:
+                return None
+
+            # Check if expired
+            age = (datetime.now(timezone.utc) - state.created_at).total_seconds()
+            if age > self._ttl:
+                del self._states[chat_id]
+                return None
+
+            state.current_offset = new_offset
+            return state
+
+    def delete(self, chat_id: str) -> None:
+        """Remove search state for a chat.
+
+        Args:
+            chat_id: The chat identifier.
+        """
+        with self._lock:
+            self._states.pop(chat_id, None)
+
+    def _cleanup_expired(self) -> None:
+        """Remove all expired states.
+
+        Note: Must be called with lock held.
+        """
+        now = datetime.now(timezone.utc)
+        expired = [
+            chat_id
+            for chat_id, state in self._states.items()
+            if (now - state.created_at).total_seconds() > self._ttl
+        ]
+        for chat_id in expired:
+            del self._states[chat_id]

--- a/issues/worklogs/88-worklog.md
+++ b/issues/worklogs/88-worklog.md
@@ -1,0 +1,98 @@
+# Issue #88: Add SearchStateManager for pagination state
+
+## Summary
+
+Implemented `SearchStateManager` to track active search sessions per chat, enabling pagination and action buttons to reference the correct results without storing full session IDs in callback data.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/search_state.py`**
+   - `SearchState`: Dataclass storing search query, filters, results, and pagination offset
+   - `SearchStateManager`: Manages search state per chat with TTL expiration
+
+2. **`tests/watcher/test_search_state.py`**
+   - 30 tests covering all functionality
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestSearchStateGetPage | 5 | get_page() with various offsets and limits |
+| TestSearchStateSessionAtIndex | 4 | session_at_index() mapping page-relative index to results |
+| TestSearchStatePaginationHelpers | 5 | has_next_page() and has_prev_page() |
+| TestSearchStateManagerSaveAndGet | 3 | Save/retrieve state, replacement on new search |
+| TestSearchStateManagerTTL | 3 | TTL expiration behavior |
+| TestSearchStateManagerUpdateOffset | 3 | Pagination offset updates |
+| TestSearchStateManagerDelete | 2 | State deletion |
+| TestSearchStateChatIdFormat | 3 | Telegram and Slack chat ID formats |
+| TestSearchStateMessageId | 2 | Integer and string message ID types |
+
+**Total: 30 new tests, all passing**
+
+## Design Decisions
+
+### Thread Safety
+
+Used `threading.Lock` for thread-safe access since the manager may be accessed from multiple async handlers concurrently:
+```python
+class SearchStateManager:
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self._states: dict[str, SearchState] = {}
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+```
+
+### TTL Expiration
+
+States expire after a configurable TTL (default 5 minutes):
+- Checked on `get()` - returns None if expired
+- Checked on `update_offset()` - returns None if expired
+- Cleanup runs on each `save()` to prevent memory leaks
+
+### Chat ID Format
+
+Follows spec convention for platform-prefixed chat IDs:
+- Telegram: `"telegram:{chat_id}"` (e.g., `"telegram:123456789"`)
+- Slack: `"slack:{channel_id}"` (e.g., `"slack:C0123456789"`)
+
+### One State Per Chat
+
+New searches replace previous state for the same chat. This is intentional per spec - users can only have one active search at a time in a chat.
+
+## Test Results
+
+- **New tests:** 30 tests, all passing
+- **Search-related tests:** 121 passing (indexer + search + search_state)
+- **Core tests:** 474 passing (2 failures due to missing optional slack_sdk dependency)
+
+## Acceptance Criteria Status
+
+- [x] `SearchState` dataclass with helper methods
+- [x] `SearchStateManager` with save/get/update/delete
+- [x] TTL expiration working correctly
+- [x] Cleanup of expired states on save
+- [x] Thread-safe access
+- [x] All tests passing
+
+## Test Requirements Status (from issue)
+
+- [x] Unit test: Save and retrieve state
+- [x] Unit test: State expires after TTL
+- [x] Unit test: New search replaces old state
+- [x] Unit test: `get_page()` returns correct slice
+- [x] Unit test: `session_at_index()` maps page index to result
+- [x] Unit test: Pagination helpers (`has_next_page`, `has_prev_page`)
+- [x] Unit test: Expired states cleaned up
+
+## Spec Reference
+
+Implements issue #88 from `.claude/specs/session-search-api.md`:
+- Search State Management section (lines 1052-1102)
+
+## Notes
+
+- No external runtime dependencies (stdlib only)
+- Uses `threading.Lock` rather than `asyncio.Lock` since the manager stores simple in-memory state
+- Message ID can be either `int` (Telegram) or `str` (Slack timestamp)

--- a/tests/watcher/test_search_state.py
+++ b/tests/watcher/test_search_state.py
@@ -1,0 +1,382 @@
+"""Tests for SearchStateManager and SearchState."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from claude_session_player.watcher.indexer import SessionInfo
+from claude_session_player.watcher.search import SearchFilters
+from claude_session_player.watcher.search_state import SearchState, SearchStateManager
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_session_info(session_id: str, summary: str | None = None) -> SessionInfo:
+    """Create a SessionInfo for testing."""
+    return SessionInfo(
+        session_id=session_id,
+        project_encoded="-Users-test-project",
+        project_display_name="project",
+        file_path=Path(f"/tmp/{session_id}.jsonl"),
+        summary=summary,
+        created_at=datetime.now(timezone.utc),
+        modified_at=datetime.now(timezone.utc),
+        size_bytes=1000,
+        line_count=100,
+        has_subagents=False,
+    )
+
+
+def make_search_state(
+    num_results: int = 10,
+    offset: int = 0,
+    message_id: int | str = 12345,
+    created_at: datetime | None = None,
+) -> SearchState:
+    """Create a SearchState for testing."""
+    results = [make_session_info(f"session-{i}", f"Summary {i}") for i in range(num_results)]
+    return SearchState(
+        query="test query",
+        filters=SearchFilters(),
+        results=results,
+        current_offset=offset,
+        message_id=message_id,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SearchState tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchStateGetPage:
+    """Tests for SearchState.get_page()."""
+
+    def test_get_first_page(self) -> None:
+        """Get first page of results."""
+        state = make_search_state(num_results=12, offset=0)
+        page = state.get_page(limit=5)
+        assert len(page) == 5
+        assert page[0].session_id == "session-0"
+        assert page[4].session_id == "session-4"
+
+    def test_get_middle_page(self) -> None:
+        """Get middle page of results."""
+        state = make_search_state(num_results=12, offset=5)
+        page = state.get_page(limit=5)
+        assert len(page) == 5
+        assert page[0].session_id == "session-5"
+        assert page[4].session_id == "session-9"
+
+    def test_get_last_page_partial(self) -> None:
+        """Get last page with fewer than limit results."""
+        state = make_search_state(num_results=12, offset=10)
+        page = state.get_page(limit=5)
+        assert len(page) == 2
+        assert page[0].session_id == "session-10"
+        assert page[1].session_id == "session-11"
+
+    def test_get_page_empty_results(self) -> None:
+        """Get page when offset is beyond results."""
+        state = make_search_state(num_results=5, offset=10)
+        page = state.get_page(limit=5)
+        assert len(page) == 0
+
+    def test_get_page_custom_limit(self) -> None:
+        """Get page with custom limit."""
+        state = make_search_state(num_results=10, offset=0)
+        page = state.get_page(limit=3)
+        assert len(page) == 3
+
+
+class TestSearchStateSessionAtIndex:
+    """Tests for SearchState.session_at_index()."""
+
+    def test_session_at_valid_index(self) -> None:
+        """Get session at valid page-relative index."""
+        state = make_search_state(num_results=10, offset=5)
+        session = state.session_at_index(0)
+        assert session is not None
+        assert session.session_id == "session-5"
+
+    def test_session_at_index_middle(self) -> None:
+        """Get session at middle of page."""
+        state = make_search_state(num_results=10, offset=5)
+        session = state.session_at_index(2)
+        assert session is not None
+        assert session.session_id == "session-7"
+
+    def test_session_at_index_out_of_bounds(self) -> None:
+        """Returns None for out of bounds index."""
+        state = make_search_state(num_results=10, offset=8)
+        # Only indices 0 and 1 are valid (sessions 8 and 9)
+        session = state.session_at_index(5)
+        assert session is None
+
+    def test_session_at_negative_index(self) -> None:
+        """Returns None for negative index."""
+        state = make_search_state(num_results=10, offset=0)
+        session = state.session_at_index(-1)
+        assert session is None
+
+
+class TestSearchStatePaginationHelpers:
+    """Tests for SearchState pagination helpers."""
+
+    def test_has_next_page_true(self) -> None:
+        """has_next_page returns True when more results exist."""
+        state = make_search_state(num_results=10, offset=0)
+        assert state.has_next_page(limit=5) is True
+
+    def test_has_next_page_false_exact(self) -> None:
+        """has_next_page returns False at exact boundary."""
+        state = make_search_state(num_results=10, offset=5)
+        assert state.has_next_page(limit=5) is False
+
+    def test_has_next_page_false_partial(self) -> None:
+        """has_next_page returns False on partial last page."""
+        state = make_search_state(num_results=8, offset=5)
+        assert state.has_next_page(limit=5) is False
+
+    def test_has_prev_page_true(self) -> None:
+        """has_prev_page returns True when offset > 0."""
+        state = make_search_state(num_results=10, offset=5)
+        assert state.has_prev_page() is True
+
+    def test_has_prev_page_false(self) -> None:
+        """has_prev_page returns False on first page."""
+        state = make_search_state(num_results=10, offset=0)
+        assert state.has_prev_page() is False
+
+
+# ---------------------------------------------------------------------------
+# SearchStateManager tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchStateManagerSaveAndGet:
+    """Tests for SearchStateManager save and get operations."""
+
+    def test_save_and_retrieve_state(self) -> None:
+        """Save state and retrieve it."""
+        manager = SearchStateManager()
+        state = make_search_state(num_results=5)
+        chat_id = "telegram:123456789"
+
+        manager.save(chat_id, state)
+        retrieved = manager.get(chat_id)
+
+        assert retrieved is not None
+        assert retrieved.query == "test query"
+        assert len(retrieved.results) == 5
+
+    def test_get_nonexistent_state(self) -> None:
+        """Get returns None for nonexistent chat_id."""
+        manager = SearchStateManager()
+        result = manager.get("telegram:nonexistent")
+        assert result is None
+
+    def test_new_search_replaces_old_state(self) -> None:
+        """New search replaces previous state for the same chat."""
+        manager = SearchStateManager()
+        chat_id = "telegram:123456789"
+
+        state1 = make_search_state(num_results=5)
+        state1.query = "first query"
+        manager.save(chat_id, state1)
+
+        state2 = make_search_state(num_results=3)
+        state2.query = "second query"
+        manager.save(chat_id, state2)
+
+        retrieved = manager.get(chat_id)
+        assert retrieved is not None
+        assert retrieved.query == "second query"
+        assert len(retrieved.results) == 3
+
+
+class TestSearchStateManagerTTL:
+    """Tests for TTL expiration."""
+
+    def test_state_expires_after_ttl(self) -> None:
+        """State is not returned after TTL expires."""
+        manager = SearchStateManager(ttl_seconds=60)
+        chat_id = "telegram:123456789"
+
+        # Create state with old created_at
+        old_time = datetime.now(timezone.utc) - timedelta(seconds=120)
+        state = make_search_state(created_at=old_time)
+
+        manager._states[chat_id] = state  # Bypass save to set old timestamp
+
+        result = manager.get(chat_id)
+        assert result is None
+
+    def test_state_not_expired_within_ttl(self) -> None:
+        """State is returned within TTL."""
+        manager = SearchStateManager(ttl_seconds=300)
+        chat_id = "telegram:123456789"
+
+        # Create state 60 seconds ago (within 300s TTL)
+        recent_time = datetime.now(timezone.utc) - timedelta(seconds=60)
+        state = make_search_state(created_at=recent_time)
+
+        manager._states[chat_id] = state
+
+        result = manager.get(chat_id)
+        assert result is not None
+
+    def test_expired_states_cleaned_on_save(self) -> None:
+        """Expired states from other chats are cleaned up on save."""
+        manager = SearchStateManager(ttl_seconds=60)
+
+        # Add an expired state
+        old_time = datetime.now(timezone.utc) - timedelta(seconds=120)
+        expired_state = make_search_state(created_at=old_time)
+        manager._states["telegram:expired"] = expired_state
+
+        # Save a new state (should trigger cleanup)
+        new_state = make_search_state()
+        manager.save("telegram:new", new_state)
+
+        # Expired state should be gone
+        assert "telegram:expired" not in manager._states
+        # New state should exist
+        assert "telegram:new" in manager._states
+
+
+class TestSearchStateManagerUpdateOffset:
+    """Tests for update_offset operation."""
+
+    def test_update_offset_success(self) -> None:
+        """Update offset successfully."""
+        manager = SearchStateManager()
+        chat_id = "telegram:123456789"
+
+        state = make_search_state(num_results=10, offset=0)
+        manager.save(chat_id, state)
+
+        updated = manager.update_offset(chat_id, 5)
+        assert updated is not None
+        assert updated.current_offset == 5
+
+    def test_update_offset_nonexistent(self) -> None:
+        """Update offset returns None for nonexistent state."""
+        manager = SearchStateManager()
+        result = manager.update_offset("telegram:nonexistent", 5)
+        assert result is None
+
+    def test_update_offset_expired_state(self) -> None:
+        """Update offset returns None for expired state."""
+        manager = SearchStateManager(ttl_seconds=60)
+        chat_id = "telegram:123456789"
+
+        old_time = datetime.now(timezone.utc) - timedelta(seconds=120)
+        state = make_search_state(created_at=old_time)
+        manager._states[chat_id] = state
+
+        result = manager.update_offset(chat_id, 5)
+        assert result is None
+        # State should also be removed
+        assert chat_id not in manager._states
+
+
+class TestSearchStateManagerDelete:
+    """Tests for delete operation."""
+
+    def test_delete_existing_state(self) -> None:
+        """Delete removes existing state."""
+        manager = SearchStateManager()
+        chat_id = "telegram:123456789"
+
+        state = make_search_state()
+        manager.save(chat_id, state)
+        assert manager.get(chat_id) is not None
+
+        manager.delete(chat_id)
+        assert manager.get(chat_id) is None
+
+    def test_delete_nonexistent_state(self) -> None:
+        """Delete does nothing for nonexistent state."""
+        manager = SearchStateManager()
+        # Should not raise
+        manager.delete("telegram:nonexistent")
+
+
+class TestSearchStateChatIdFormat:
+    """Tests for chat ID format handling."""
+
+    def test_telegram_chat_id_format(self) -> None:
+        """Telegram chat IDs work correctly."""
+        manager = SearchStateManager()
+        chat_id = "telegram:123456789"
+
+        state = make_search_state()
+        manager.save(chat_id, state)
+
+        retrieved = manager.get(chat_id)
+        assert retrieved is not None
+
+    def test_slack_chat_id_format(self) -> None:
+        """Slack channel IDs work correctly."""
+        manager = SearchStateManager()
+        chat_id = "slack:C0123456789"
+
+        state = make_search_state()
+        manager.save(chat_id, state)
+
+        retrieved = manager.get(chat_id)
+        assert retrieved is not None
+
+    def test_different_platforms_separate_states(self) -> None:
+        """Different platforms have separate state spaces."""
+        manager = SearchStateManager()
+
+        telegram_state = make_search_state(num_results=5)
+        telegram_state.query = "telegram search"
+        manager.save("telegram:123", telegram_state)
+
+        slack_state = make_search_state(num_results=3)
+        slack_state.query = "slack search"
+        manager.save("slack:C123", slack_state)
+
+        telegram_retrieved = manager.get("telegram:123")
+        slack_retrieved = manager.get("slack:C123")
+
+        assert telegram_retrieved is not None
+        assert telegram_retrieved.query == "telegram search"
+        assert slack_retrieved is not None
+        assert slack_retrieved.query == "slack search"
+
+
+class TestSearchStateMessageId:
+    """Tests for message ID storage."""
+
+    def test_telegram_message_id_int(self) -> None:
+        """Telegram integer message IDs work."""
+        state = SearchState(
+            query="test",
+            filters=SearchFilters(),
+            results=[],
+            current_offset=0,
+            message_id=12345,
+        )
+        assert state.message_id == 12345
+
+    def test_slack_message_ts_string(self) -> None:
+        """Slack timestamp message IDs work."""
+        state = SearchState(
+            query="test",
+            filters=SearchFilters(),
+            results=[],
+            current_offset=0,
+            message_id="1706789012.123456",
+        )
+        assert state.message_id == "1706789012.123456"


### PR DESCRIPTION
## Summary
Add `SearchStateManager` component that tracks active search sessions per chat, enabling pagination and action buttons to reference the correct results by index.

## Context
When a user searches and clicks "Next page" or "Watch #2", we need to know which search results they're referring to. Since Telegram callback data is limited to 64 bytes, we can't embed full session IDs. Instead, we store the search state server-side and reference results by index.

## Changes
- Add `SearchState` dataclass with helper methods for pagination
- Add `SearchStateManager` for per-chat state management with TTL expiration
- 30 new tests covering all functionality

## Components
- `SearchState`: Stores query, filters, results list, and current offset
- `SearchStateManager`: Manages states per chat with save/get/update/delete operations

## Features
- TTL expiration (configurable, default 5 minutes)
- Thread-safe access using `threading.Lock`
- Automatic cleanup of expired states on save
- Support for Telegram (`telegram:123456`) and Slack (`slack:C0123`) chat ID formats

## Test plan
- [x] Save and retrieve state
- [x] State expires after TTL
- [x] New search replaces old state
- [x] `get_page()` returns correct slice
- [x] `session_at_index()` maps page index to result
- [x] Pagination helpers work correctly
- [x] Expired states cleaned up on save

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)