### PR TITLE
Issue #90: Add BotRouter for Slack/Telegram webhook routing

### DIFF
--- a/claude_session_player/watcher/bot_router.py
+++ b/claude_session_player/watcher/bot_router.py
@@ -1,0 +1,450 @@
+"""Bot router for Slack and Telegram webhook routing.
+
+This module provides:
+- BotRouter: Routes incoming webhooks from Slack and Telegram to appropriate handlers
+- verify_slack_signature(): Verifies Slack request signatures using HMAC-SHA256
+- register_bot_routes(): Registers bot webhook routes on an aiohttp application
+
+Endpoint Reference:
+- POST /slack/commands: Slack slash commands
+- POST /slack/interactions: Slack button clicks, menu selections
+- POST /telegram/webhook: All Telegram updates (messages, callbacks)
+
+Security:
+- Slack: HMAC-SHA256 signature verification with timestamp validation
+- Telegram: No built-in signature; security via secret webhook URL path
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+from aiohttp import web
+
+if TYPE_CHECKING:
+    from claude_session_player.watcher.config import BotConfig
+
+logger = logging.getLogger(__name__)
+
+# Type aliases for command handlers
+# SlackCommandHandler receives: command, text, user_id, channel_id, response_url
+SlackCommandHandler = Callable[
+    [str, str, str, str, str], Awaitable[Optional[dict[str, Any]]]
+]
+# SlackInteractionHandler receives: action_id, value, payload
+SlackInteractionHandler = Callable[
+    [str, Optional[str], dict[str, Any]], Awaitable[None]
+]
+# TelegramCommandHandler receives: command, args, chat_id, message_id
+TelegramCommandHandler = Callable[[str, str, int, int], Awaitable[None]]
+# TelegramCallbackHandler receives: callback_data, chat_id, message_id, callback_query_id
+TelegramCallbackHandler = Callable[[str, int, int, str], Awaitable[None]]
+
+
+# Maximum age for Slack request timestamps (5 minutes in seconds)
+SLACK_TIMESTAMP_MAX_AGE = 300
+
+
+def verify_slack_signature(
+    body: bytes,
+    timestamp: str | None,
+    signature: str | None,
+    signing_secret: str,
+) -> bool:
+    """Verify a Slack request signature.
+
+    Slack signs requests with HMAC-SHA256 using the signing secret.
+    The signature is computed over "v0:{timestamp}:{body}".
+
+    Args:
+        body: Raw request body bytes.
+        timestamp: X-Slack-Request-Timestamp header value.
+        signature: X-Slack-Signature header value (format: "v0=...").
+        signing_secret: Slack app signing secret.
+
+    Returns:
+        True if signature is valid and timestamp is recent, False otherwise.
+    """
+    if not timestamp or not signature:
+        return False
+
+    # Check timestamp is recent (within 5 minutes)
+    try:
+        request_time = int(timestamp)
+        current_time = int(time.time())
+        if abs(current_time - request_time) > SLACK_TIMESTAMP_MAX_AGE:
+            logger.warning(
+                "Slack timestamp too old: %d (current: %d)", request_time, current_time
+            )
+            return False
+    except ValueError:
+        logger.warning("Invalid Slack timestamp: %s", timestamp)
+        return False
+
+    # Compute expected signature
+    sig_basestring = f"v0:{timestamp}:{body.decode('utf-8')}"
+    expected_sig = (
+        "v0="
+        + hmac.new(
+            signing_secret.encode("utf-8"),
+            sig_basestring.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+    # Constant-time comparison to prevent timing attacks
+    if not hmac.compare_digest(expected_sig, signature):
+        logger.warning("Slack signature mismatch")
+        return False
+
+    return True
+
+
+@dataclass
+class BotRouter:
+    """Routes incoming webhooks from Slack and Telegram to handlers.
+
+    Handles signature verification for Slack requests and parses payloads
+    for both platforms. Routes commands and interactions to registered handlers.
+
+    Example:
+        router = BotRouter(bot_config)
+
+        # Register handlers
+        router.register_slack_command("/search", handle_search)
+        router.register_telegram_command("search", handle_search)
+
+        # Register routes on app
+        register_bot_routes(app, router)
+    """
+
+    bot_config: BotConfig
+
+    # Handler registries
+    _slack_command_handlers: dict[str, SlackCommandHandler] = field(
+        default_factory=dict, repr=False
+    )
+    _slack_interaction_handlers: dict[str, SlackInteractionHandler] = field(
+        default_factory=dict, repr=False
+    )
+    _telegram_command_handlers: dict[str, TelegramCommandHandler] = field(
+        default_factory=dict, repr=False
+    )
+    _telegram_callback_handlers: dict[str, TelegramCallbackHandler] = field(
+        default_factory=dict, repr=False
+    )
+
+    def register_slack_command(
+        self, command: str, handler: SlackCommandHandler
+    ) -> None:
+        """Register a handler for a Slack slash command.
+
+        Args:
+            command: Command name including leading slash (e.g., "/search").
+            handler: Async function to handle the command.
+        """
+        self._slack_command_handlers[command] = handler
+
+    def register_slack_interaction(
+        self, action_prefix: str, handler: SlackInteractionHandler
+    ) -> None:
+        """Register a handler for Slack interactions by action_id prefix.
+
+        Args:
+            action_prefix: Prefix for action_id (e.g., "watch:" matches "watch:abc123").
+            handler: Async function to handle the interaction.
+        """
+        self._slack_interaction_handlers[action_prefix] = handler
+
+    def register_telegram_command(
+        self, command: str, handler: TelegramCommandHandler
+    ) -> None:
+        """Register a handler for a Telegram bot command.
+
+        Args:
+            command: Command name without leading slash (e.g., "search").
+            handler: Async function to handle the command.
+        """
+        self._telegram_command_handlers[command] = handler
+
+    def register_telegram_callback(
+        self, action_prefix: str, handler: TelegramCallbackHandler
+    ) -> None:
+        """Register a handler for Telegram callback queries by data prefix.
+
+        Args:
+            action_prefix: Prefix for callback_data (e.g., "w:" matches "w:0:abc").
+            handler: Async function to handle the callback.
+        """
+        self._telegram_callback_handlers[action_prefix] = handler
+
+    async def handle_slack_command(self, request: web.Request) -> web.Response:
+        """Handle POST /slack/commands - Slack slash commands.
+
+        Verifies request signature, parses form data, and routes to
+        the appropriate command handler.
+
+        Args:
+            request: aiohttp Request object.
+
+        Returns:
+            200 OK if valid and handler found.
+            400 Bad Request if unknown command.
+            401 Unauthorized if signature verification fails.
+        """
+        # Read body for signature verification
+        body = await request.read()
+
+        # Verify signature
+        if not self.bot_config.slack_signing_secret:
+            logger.warning("Slack signing secret not configured")
+            return web.Response(status=401, text="Signing secret not configured")
+
+        timestamp = request.headers.get("X-Slack-Request-Timestamp")
+        signature = request.headers.get("X-Slack-Signature")
+
+        if not verify_slack_signature(
+            body, timestamp, signature, self.bot_config.slack_signing_secret
+        ):
+            return web.Response(status=401, text="Invalid signature")
+
+        # Parse form data
+        # Note: We can't use request.post() after reading body, so parse manually
+        try:
+            form_data = _parse_form_data(body.decode("utf-8"))
+        except Exception as e:
+            logger.warning("Failed to parse Slack command form data: %s", e)
+            return web.Response(status=400, text="Invalid form data")
+
+        command = form_data.get("command", "")
+        text = form_data.get("text", "")
+        user_id = form_data.get("user_id", "")
+        channel_id = form_data.get("channel_id", "")
+        response_url = form_data.get("response_url", "")
+
+        logger.info(
+            "Received Slack command: %s %s from user %s in %s",
+            command,
+            text,
+            user_id,
+            channel_id,
+        )
+
+        # Find handler
+        handler = self._slack_command_handlers.get(command)
+        if not handler:
+            logger.warning("Unknown Slack command: %s", command)
+            return web.Response(status=400, text=f"Unknown command: {command}")
+
+        # Call handler - returns immediate response or None for async processing
+        try:
+            immediate_response = await handler(
+                command, text, user_id, channel_id, response_url
+            )
+            if immediate_response:
+                return web.json_response(immediate_response)
+            return web.Response(status=200)
+        except Exception as e:
+            logger.exception("Error handling Slack command %s: %s", command, e)
+            return web.Response(status=200)  # Slack expects 200 even on errors
+
+    async def handle_slack_interaction(self, request: web.Request) -> web.Response:
+        """Handle POST /slack/interactions - button clicks, menu selections.
+
+        Verifies request signature, parses JSON payload from form data,
+        and routes to the appropriate interaction handler.
+
+        Args:
+            request: aiohttp Request object.
+
+        Returns:
+            200 OK if valid and handler found.
+            400 Bad Request if invalid payload.
+            401 Unauthorized if signature verification fails.
+        """
+        # Read body for signature verification
+        body = await request.read()
+
+        # Verify signature
+        if not self.bot_config.slack_signing_secret:
+            logger.warning("Slack signing secret not configured")
+            return web.Response(status=401, text="Signing secret not configured")
+
+        timestamp = request.headers.get("X-Slack-Request-Timestamp")
+        signature = request.headers.get("X-Slack-Signature")
+
+        if not verify_slack_signature(
+            body, timestamp, signature, self.bot_config.slack_signing_secret
+        ):
+            return web.Response(status=401, text="Invalid signature")
+
+        # Parse form data to get payload JSON
+        try:
+            form_data = _parse_form_data(body.decode("utf-8"))
+            payload_str = form_data.get("payload", "")
+            if not payload_str:
+                return web.Response(status=400, text="Missing payload")
+            payload = json.loads(payload_str)
+        except (json.JSONDecodeError, Exception) as e:
+            logger.warning("Failed to parse Slack interaction payload: %s", e)
+            return web.Response(status=400, text="Invalid payload")
+
+        # Extract action info
+        actions = payload.get("actions", [])
+        if not actions:
+            logger.warning("No actions in Slack interaction payload")
+            return web.Response(status=400, text="No actions")
+
+        action = actions[0]
+        action_id = action.get("action_id", "")
+        # Value can be in 'value' or 'selected_option.value'
+        value = action.get("value")
+        if value is None:
+            selected_option = action.get("selected_option", {})
+            value = selected_option.get("value")
+
+        logger.info("Received Slack interaction: action_id=%s value=%s", action_id, value)
+
+        # Find handler by prefix match
+        handler = None
+        for prefix, h in self._slack_interaction_handlers.items():
+            if action_id.startswith(prefix) or action_id == prefix:
+                handler = h
+                break
+
+        if not handler:
+            logger.warning("No handler for Slack interaction: %s", action_id)
+            return web.Response(status=200)  # Acknowledge even without handler
+
+        # Call handler
+        try:
+            await handler(action_id, value, payload)
+        except Exception as e:
+            logger.exception("Error handling Slack interaction %s: %s", action_id, e)
+
+        return web.Response(status=200)
+
+    async def handle_telegram_webhook(self, request: web.Request) -> web.Response:
+        """Handle POST /telegram/webhook - all Telegram updates.
+
+        Parses Update JSON and routes message commands and callback queries
+        to the appropriate handlers.
+
+        Args:
+            request: aiohttp Request object.
+
+        Returns:
+            200 OK always (Telegram expects this).
+        """
+        try:
+            update = await request.json()
+        except json.JSONDecodeError as e:
+            logger.warning("Failed to parse Telegram update: %s", e)
+            return web.Response(status=200)  # Telegram expects 200 even on errors
+
+        # Handle message with text (commands)
+        message = update.get("message")
+        if message and message.get("text"):
+            text = message["text"]
+            chat = message.get("chat", {})
+            chat_id = chat.get("id", 0)
+            message_id = message.get("message_id", 0)
+
+            # Check if it's a command (starts with /)
+            if text.startswith("/"):
+                # Parse command and args
+                parts = text.split(maxsplit=1)
+                command_part = parts[0][1:]  # Remove leading /
+                # Handle @botname suffix in groups
+                if "@" in command_part:
+                    command_part = command_part.split("@")[0]
+                args = parts[1] if len(parts) > 1 else ""
+
+                logger.info(
+                    "Received Telegram command: /%s %s from chat %s",
+                    command_part,
+                    args,
+                    chat_id,
+                )
+
+                # Find handler
+                handler = self._telegram_command_handlers.get(command_part)
+                if handler:
+                    try:
+                        await handler(command_part, args, chat_id, message_id)
+                    except Exception as e:
+                        logger.exception(
+                            "Error handling Telegram command %s: %s", command_part, e
+                        )
+                else:
+                    logger.debug("No handler for Telegram command: %s", command_part)
+
+        # Handle callback query (button clicks)
+        callback_query = update.get("callback_query")
+        if callback_query:
+            callback_data = callback_query.get("data", "")
+            callback_id = callback_query.get("id", "")
+            callback_message = callback_query.get("message", {})
+            chat = callback_message.get("chat", {})
+            chat_id = chat.get("id", 0)
+            message_id = callback_message.get("message_id", 0)
+
+            logger.info(
+                "Received Telegram callback: data=%s from chat %s",
+                callback_data,
+                chat_id,
+            )
+
+            # Find handler by prefix match
+            handler = None
+            for prefix, h in self._telegram_callback_handlers.items():
+                if callback_data.startswith(prefix):
+                    handler = h
+                    break
+
+            if handler:
+                try:
+                    await handler(callback_data, chat_id, message_id, callback_id)
+                except Exception as e:
+                    logger.exception(
+                        "Error handling Telegram callback %s: %s", callback_data, e
+                    )
+            else:
+                logger.debug("No handler for Telegram callback: %s", callback_data)
+
+        return web.Response(status=200)
+
+
+def _parse_form_data(data: str) -> dict[str, str]:
+    """Parse URL-encoded form data.
+
+    Args:
+        data: URL-encoded string (key1=value1&key2=value2).
+
+    Returns:
+        Dict mapping keys to decoded values.
+    """
+    from urllib.parse import parse_qs, unquote_plus
+
+    parsed = parse_qs(data, keep_blank_values=True)
+    # parse_qs returns lists, we want single values
+    return {k: unquote_plus(v[0]) if v else "" for k, v in parsed.items()}
+
+
+def register_bot_routes(app: web.Application, router: BotRouter) -> None:
+    """Register Slack and Telegram webhook routes on an aiohttp application.
+
+    Args:
+        app: aiohttp Application to register routes on.
+        router: BotRouter instance to handle requests.
+    """
+    app.router.add_post("/slack/commands", router.handle_slack_command)
+    app.router.add_post("/slack/interactions", router.handle_slack_interaction)
+    app.router.add_post("/telegram/webhook", router.handle_telegram_webhook)

--- a/claude_session_player/watcher/config.py
+++ b/claude_session_player/watcher/config.py
@@ -77,14 +77,20 @@ class BotConfig:
 
     telegram_token: str | None = None
     slack_token: str | None = None
+    slack_signing_secret: str | None = None
 
     def to_dict(self) -> dict:
         """Serialize to dict for YAML storage."""
         result: dict = {}
         if self.telegram_token is not None:
             result["telegram"] = {"token": self.telegram_token}
-        if self.slack_token is not None:
-            result["slack"] = {"token": self.slack_token}
+        if self.slack_token is not None or self.slack_signing_secret is not None:
+            slack_config: dict = {}
+            if self.slack_token is not None:
+                slack_config["token"] = self.slack_token
+            if self.slack_signing_secret is not None:
+                slack_config["signing_secret"] = self.slack_signing_secret
+            result["slack"] = slack_config
         return result
 
     @classmethod
@@ -92,13 +98,19 @@ class BotConfig:
         """Deserialize from dict."""
         telegram_token = None
         slack_token = None
+        slack_signing_secret = None
 
         if "telegram" in data and data["telegram"]:
             telegram_token = data["telegram"].get("token")
         if "slack" in data and data["slack"]:
             slack_token = data["slack"].get("token")
+            slack_signing_secret = data["slack"].get("signing_secret")
 
-        return cls(telegram_token=telegram_token, slack_token=slack_token)
+        return cls(
+            telegram_token=telegram_token,
+            slack_token=slack_token,
+            slack_signing_secret=slack_signing_secret,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/issues/worklogs/90-worklog.md
+++ b/issues/worklogs/90-worklog.md
@@ -1,0 +1,138 @@
+# Issue #90: Add BotRouter for Slack/Telegram webhook routing
+
+## Summary
+
+Implemented `BotRouter` component that receives incoming webhooks from Slack and Telegram and routes them to appropriate handlers. Includes Slack signature verification (HMAC-SHA256) and Telegram webhook parsing.
+
+## Changes Made
+
+### New Files
+
+1. **`claude_session_player/watcher/bot_router.py`**
+   - `verify_slack_signature()`: Verifies Slack request signatures using HMAC-SHA256
+   - `BotRouter`: Routes incoming webhooks to registered handlers
+   - `register_bot_routes()`: Registers webhook routes on aiohttp application
+   - `_parse_form_data()`: Parses URL-encoded form data
+   - Type aliases for handler signatures
+
+2. **`tests/watcher/test_bot_router.py`**
+   - 40 tests covering all functionality
+
+### Modified Files
+
+1. **`claude_session_player/watcher/config.py`**
+   - Added `slack_signing_secret` field to `BotConfig` dataclass
+   - Updated `to_dict()` and `from_dict()` methods for serialization
+
+## Test Coverage
+
+| Test Class | Count | Coverage |
+|------------|-------|----------|
+| TestVerifySlackSignatureValid | 2 | Valid signature verification |
+| TestVerifySlackSignatureInvalid | 3 | Invalid signature detection |
+| TestVerifySlackSignatureExpiredTimestamp | 3 | Timestamp validation (5 min window) |
+| TestVerifySlackSignatureMissingFields | 4 | Missing headers handling |
+| TestSlackCommandRouting | 3 | Slash command routing |
+| TestSlackCommandSignatureVerification | 3 | Signature verification in handlers |
+| TestSlackInteractionRouting | 3 | Button click/menu selection routing |
+| TestTelegramMessageCommandRouting | 4 | Message command routing |
+| TestTelegramCallbackQueryRouting | 3 | Callback query routing |
+| TestTelegramInvalidPayload | 2 | Invalid payload handling |
+| TestParseFormData | 3 | URL-encoded form parsing |
+| TestRegisterBotRoutes | 1 | Route registration |
+| TestHandlerErrorHandling | 3 | Exception handling in handlers |
+| TestHandlerRegistration | 3 | Handler registration methods |
+
+**Total: 40 new tests, all passing**
+
+## Design Decisions
+
+### Slack Signature Verification
+
+Implemented exactly per Slack API documentation:
+```python
+def verify_slack_signature(body, timestamp, signature, signing_secret):
+    # 1. Check timestamp is within 5 minutes
+    # 2. Compute HMAC-SHA256 of "v0:{timestamp}:{body}"
+    # 3. Constant-time comparison to prevent timing attacks
+```
+
+### Handler Registration Pattern
+
+Used prefix-based matching for interactions and callbacks:
+- Slack: `action_id.startswith(prefix)` for "watch:", "preview:", etc.
+- Telegram: `callback_data.startswith(prefix)` for "w:", "p:", "s:", etc.
+
+This allows registering handlers like:
+```python
+router.register_slack_interaction("watch:", handle_watch)
+router.register_telegram_callback("w:", handle_watch)
+```
+
+### Error Handling
+
+Both Slack and Telegram expect 200 OK even on handler errors:
+- Slack: Returns 200 to acknowledge, actual response via response_url
+- Telegram: Returns 200 always to prevent retry storms
+
+Handler exceptions are logged but don't propagate to HTTP response.
+
+### Type Aliases
+
+Used `Optional[]` syntax instead of `| None` for Python 3.9 compatibility in type aliases that are evaluated at runtime:
+```python
+SlackCommandHandler = Callable[
+    [str, str, str, str, str], Awaitable[Optional[dict[str, Any]]]
+]
+```
+
+### Form Data Parsing
+
+Created custom `_parse_form_data()` because we read the body for signature verification before aiohttp can parse it:
+```python
+body = await request.read()  # For signature verification
+form_data = _parse_form_data(body.decode("utf-8"))  # Manual parsing
+```
+
+## Test Results
+
+- **New tests:** 40 tests, all passing
+- **Search-related tests:** 283 passing (indexer + search + search_state + rate_limit + bot_router + config)
+- **Core tests:** 474 passing (2 failures due to missing optional slack_sdk dependency - pre-existing)
+
+## Acceptance Criteria Status
+
+- [x] Slack signature verification working
+- [x] Slack commands routed to handlers
+- [x] Slack interactions routed to handlers
+- [x] Telegram webhook parses updates
+- [x] Telegram commands routed to handlers
+- [x] Telegram callbacks routed to handlers
+- [x] 401 returned for invalid signatures
+- [x] All tests passing
+
+## Test Requirements Status (from issue)
+
+- [x] Unit test: Slack signature verification (valid)
+- [x] Unit test: Slack signature verification (invalid)
+- [x] Unit test: Slack signature verification (expired timestamp)
+- [x] Unit test: Route /search command correctly
+- [x] Unit test: Route button interaction correctly
+- [x] Unit test: Telegram webhook parses message command
+- [x] Unit test: Telegram webhook parses callback query
+
+## Spec Reference
+
+Implements issue #90 from `.claude/specs/session-search-api.md`:
+- Bot Command Infrastructure section (lines 854-1050)
+- Slack slash commands endpoint
+- Slack interactions endpoint
+- Telegram webhook endpoint
+- Signature verification
+
+## Notes
+
+- No external runtime dependencies added (stdlib only for signature verification)
+- Uses `hmac.compare_digest()` for constant-time signature comparison (prevents timing attacks)
+- Handler registration is flexible with prefix matching for action routing
+- Telegram has no built-in signature verification; security via secret webhook URL path

--- a/tests/watcher/test_bot_router.py
+++ b/tests/watcher/test_bot_router.py
@@ -1,0 +1,944 @@
+"""Tests for the BotRouter module."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from claude_session_player.watcher.bot_router import (
+    SLACK_TIMESTAMP_MAX_AGE,
+    BotRouter,
+    _parse_form_data,
+    register_bot_routes,
+    verify_slack_signature,
+)
+from claude_session_player.watcher.config import BotConfig
+
+
+# --- Mock HTTP Request/Response ---
+
+
+@dataclass
+class MockRequest:
+    """Mock aiohttp request for testing."""
+
+    headers: dict[str, str] = field(default_factory=dict)
+    _body: bytes = b""
+    _json_data: dict | None = None
+    _json_error: bool = False
+
+    async def read(self) -> bytes:
+        """Return raw body bytes."""
+        return self._body
+
+    async def json(self) -> dict:
+        """Return JSON body."""
+        if self._json_error:
+            raise json.JSONDecodeError("Invalid JSON", "", 0)
+        return self._json_data or {}
+
+
+def make_slack_signature(body: str, timestamp: str, signing_secret: str) -> str:
+    """Generate a valid Slack signature for testing."""
+    sig_basestring = f"v0:{timestamp}:{body}"
+    return (
+        "v0="
+        + hmac.new(
+            signing_secret.encode("utf-8"),
+            sig_basestring.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+    )
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def bot_config() -> BotConfig:
+    """Create a BotConfig with test credentials."""
+    return BotConfig(
+        telegram_token="test-telegram-token",
+        slack_token="xoxb-test-slack-token",
+        slack_signing_secret="test-signing-secret-12345",
+    )
+
+
+@pytest.fixture
+def bot_config_no_slack_secret() -> BotConfig:
+    """Create a BotConfig without Slack signing secret."""
+    return BotConfig(
+        telegram_token="test-telegram-token",
+        slack_token="xoxb-test-slack-token",
+        slack_signing_secret=None,
+    )
+
+
+@pytest.fixture
+def router(bot_config: BotConfig) -> BotRouter:
+    """Create a BotRouter instance."""
+    return BotRouter(bot_config=bot_config)
+
+
+@pytest.fixture
+def current_timestamp() -> str:
+    """Return current Unix timestamp as string."""
+    return str(int(time.time()))
+
+
+# --- Tests for verify_slack_signature ---
+
+
+class TestVerifySlackSignatureValid:
+    """Tests for valid Slack signature verification."""
+
+    def test_valid_signature(self) -> None:
+        """Valid signature returns True."""
+        body = b"command=/search&text=auth"
+        timestamp = str(int(time.time()))
+        signing_secret = "test-secret"
+        signature = make_slack_signature(body.decode(), timestamp, signing_secret)
+
+        result = verify_slack_signature(body, timestamp, signature, signing_secret)
+
+        assert result is True
+
+    def test_valid_signature_with_special_chars(self) -> None:
+        """Valid signature with special characters in body returns True."""
+        body = b"command=/search&text=auth%20bug%20%22test%22"
+        timestamp = str(int(time.time()))
+        signing_secret = "test-secret-abc123"
+        signature = make_slack_signature(body.decode(), timestamp, signing_secret)
+
+        result = verify_slack_signature(body, timestamp, signature, signing_secret)
+
+        assert result is True
+
+
+class TestVerifySlackSignatureInvalid:
+    """Tests for invalid Slack signature verification."""
+
+    def test_invalid_signature(self) -> None:
+        """Invalid signature returns False."""
+        body = b"command=/search&text=auth"
+        timestamp = str(int(time.time()))
+        signing_secret = "test-secret"
+        wrong_signature = "v0=invalid_signature_hash"
+
+        result = verify_slack_signature(body, timestamp, wrong_signature, signing_secret)
+
+        assert result is False
+
+    def test_tampered_body(self) -> None:
+        """Signature for different body returns False."""
+        original_body = b"command=/search&text=auth"
+        tampered_body = b"command=/search&text=hack"
+        timestamp = str(int(time.time()))
+        signing_secret = "test-secret"
+        signature = make_slack_signature(original_body.decode(), timestamp, signing_secret)
+
+        result = verify_slack_signature(tampered_body, timestamp, signature, signing_secret)
+
+        assert result is False
+
+    def test_wrong_signing_secret(self) -> None:
+        """Signature with different secret returns False."""
+        body = b"command=/search&text=auth"
+        timestamp = str(int(time.time()))
+        signature = make_slack_signature(body.decode(), timestamp, "correct-secret")
+
+        result = verify_slack_signature(body, timestamp, signature, "wrong-secret")
+
+        assert result is False
+
+
+class TestVerifySlackSignatureExpiredTimestamp:
+    """Tests for Slack signature with expired timestamp."""
+
+    def test_old_timestamp(self) -> None:
+        """Timestamp older than 5 minutes returns False."""
+        body = b"command=/search&text=auth"
+        old_timestamp = str(int(time.time()) - SLACK_TIMESTAMP_MAX_AGE - 60)  # 6 minutes old
+        signing_secret = "test-secret"
+        signature = make_slack_signature(body.decode(), old_timestamp, signing_secret)
+
+        result = verify_slack_signature(body, old_timestamp, signature, signing_secret)
+
+        assert result is False
+
+    def test_future_timestamp(self) -> None:
+        """Timestamp more than 5 minutes in future returns False."""
+        body = b"command=/search&text=auth"
+        future_timestamp = str(int(time.time()) + SLACK_TIMESTAMP_MAX_AGE + 60)  # 6 minutes future
+        signing_secret = "test-secret"
+        signature = make_slack_signature(body.decode(), future_timestamp, signing_secret)
+
+        result = verify_slack_signature(body, future_timestamp, signature, signing_secret)
+
+        assert result is False
+
+    def test_timestamp_at_boundary(self) -> None:
+        """Timestamp exactly at 5 minute boundary returns True."""
+        body = b"command=/search&text=auth"
+        # 4 minutes 59 seconds old should be OK
+        boundary_timestamp = str(int(time.time()) - SLACK_TIMESTAMP_MAX_AGE + 1)
+        signing_secret = "test-secret"
+        signature = make_slack_signature(body.decode(), boundary_timestamp, signing_secret)
+
+        result = verify_slack_signature(body, boundary_timestamp, signature, signing_secret)
+
+        assert result is True
+
+
+class TestVerifySlackSignatureMissingFields:
+    """Tests for Slack signature with missing fields."""
+
+    def test_missing_timestamp(self) -> None:
+        """Missing timestamp returns False."""
+        body = b"command=/search&text=auth"
+        signature = "v0=somehash"
+        signing_secret = "test-secret"
+
+        result = verify_slack_signature(body, None, signature, signing_secret)
+
+        assert result is False
+
+    def test_missing_signature(self) -> None:
+        """Missing signature returns False."""
+        body = b"command=/search&text=auth"
+        timestamp = str(int(time.time()))
+        signing_secret = "test-secret"
+
+        result = verify_slack_signature(body, timestamp, None, signing_secret)
+
+        assert result is False
+
+    def test_empty_timestamp(self) -> None:
+        """Empty timestamp returns False."""
+        body = b"command=/search&text=auth"
+        signing_secret = "test-secret"
+
+        result = verify_slack_signature(body, "", "v0=hash", signing_secret)
+
+        assert result is False
+
+    def test_invalid_timestamp_format(self) -> None:
+        """Non-numeric timestamp returns False."""
+        body = b"command=/search&text=auth"
+        signing_secret = "test-secret"
+
+        result = verify_slack_signature(body, "not-a-number", "v0=hash", signing_secret)
+
+        assert result is False
+
+
+# --- Tests for BotRouter Slack command handling ---
+
+
+class TestSlackCommandRouting:
+    """Tests for Slack command routing."""
+
+    async def test_route_search_command(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Route /search command to registered handler."""
+        # Register handler
+        handler_called = False
+        handler_args: tuple = ()
+
+        async def search_handler(
+            command: str, text: str, user_id: str, channel_id: str, response_url: str
+        ) -> dict | None:
+            nonlocal handler_called, handler_args
+            handler_called = True
+            handler_args = (command, text, user_id, channel_id, response_url)
+            return None
+
+        router.register_slack_command("/search", search_handler)
+
+        # Create valid request
+        body = "command=%2Fsearch&text=auth+bug&user_id=U123&channel_id=C456&response_url=https%3A%2F%2Fhooks.slack.com%2Ftest"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 200
+        assert handler_called
+        assert handler_args[0] == "/search"
+        assert handler_args[1] == "auth bug"
+        assert handler_args[2] == "U123"
+        assert handler_args[3] == "C456"
+        assert "hooks.slack.com" in handler_args[4]
+
+    async def test_handler_returns_immediate_response(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Handler can return an immediate response dict."""
+        async def handler(
+            command: str, text: str, user_id: str, channel_id: str, response_url: str
+        ) -> dict:
+            return {"text": "Processing...", "response_type": "ephemeral"}
+
+        router.register_slack_command("/search", handler)
+
+        body = "command=%2Fsearch&text=test"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 200
+        assert response.content_type == "application/json"
+
+    async def test_unknown_command_returns_400(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Unknown command returns 400."""
+        body = "command=%2Funknown&text=test"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 400
+
+
+class TestSlackCommandSignatureVerification:
+    """Tests for Slack command signature verification."""
+
+    async def test_invalid_signature_returns_401(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Invalid signature returns 401."""
+        body = "command=%2Fsearch&text=test"
+        invalid_signature = "v0=invalid"
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": invalid_signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 401
+
+    async def test_expired_timestamp_returns_401(
+        self, router: BotRouter
+    ) -> None:
+        """Expired timestamp returns 401."""
+        old_timestamp = str(int(time.time()) - 600)  # 10 minutes old
+        body = "command=%2Fsearch&text=test"
+        signature = make_slack_signature(
+            body, old_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": old_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 401
+
+    async def test_no_signing_secret_returns_401(
+        self, bot_config_no_slack_secret: BotConfig, current_timestamp: str
+    ) -> None:
+        """No signing secret configured returns 401."""
+        router = BotRouter(bot_config=bot_config_no_slack_secret)
+        body = "command=%2Fsearch&text=test"
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": "v0=hash",
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_command(request)
+
+        assert response.status == 401
+
+
+# --- Tests for BotRouter Slack interaction handling ---
+
+
+class TestSlackInteractionRouting:
+    """Tests for Slack interaction routing."""
+
+    async def test_route_watch_action(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Route watch button action to registered handler."""
+        handler_called = False
+        handler_args: tuple = ()
+
+        async def watch_handler(
+            action_id: str, value: str | None, payload: dict
+        ) -> None:
+            nonlocal handler_called, handler_args
+            handler_called = True
+            handler_args = (action_id, value, payload)
+
+        router.register_slack_interaction("watch:", watch_handler)
+
+        payload = {
+            "type": "block_actions",
+            "actions": [
+                {"action_id": "watch:session123", "value": "abc123"}
+            ],
+            "channel": {"id": "C456"},
+            "user": {"id": "U123"},
+        }
+        body = f"payload={json.dumps(payload)}"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_interaction(request)
+
+        assert response.status == 200
+        assert handler_called
+        assert handler_args[0] == "watch:session123"
+        assert handler_args[1] == "abc123"
+        assert handler_args[2]["channel"]["id"] == "C456"
+
+    async def test_selected_option_value(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Extract value from selected_option for dropdown menus."""
+        handler_called = False
+        received_value: str | None = None
+
+        async def handler(action_id: str, value: str | None, payload: dict) -> None:
+            nonlocal handler_called, received_value
+            handler_called = True
+            received_value = value
+
+        router.register_slack_interaction("select:", handler)
+
+        payload = {
+            "type": "block_actions",
+            "actions": [
+                {
+                    "action_id": "select:menu",
+                    "selected_option": {"value": "option1"}
+                }
+            ],
+        }
+        body = f"payload={json.dumps(payload)}"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        await router.handle_slack_interaction(request)
+
+        assert handler_called
+        assert received_value == "option1"
+
+    async def test_no_handler_returns_200(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """No handler for action still returns 200 to acknowledge."""
+        payload = {
+            "type": "block_actions",
+            "actions": [{"action_id": "unknown:action", "value": "test"}],
+        }
+        body = f"payload={json.dumps(payload)}"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_interaction(request)
+
+        # Slack expects 200 even without handler
+        assert response.status == 200
+
+
+# --- Tests for BotRouter Telegram webhook handling ---
+
+
+class TestTelegramMessageCommandRouting:
+    """Tests for Telegram message command routing."""
+
+    async def test_route_search_command(self, router: BotRouter) -> None:
+        """Route /search command to registered handler."""
+        handler_called = False
+        handler_args: tuple = ()
+
+        async def search_handler(
+            command: str, args: str, chat_id: int, message_id: int
+        ) -> None:
+            nonlocal handler_called, handler_args
+            handler_called = True
+            handler_args = (command, args, chat_id, message_id)
+
+        router.register_telegram_command("search", search_handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123456789,
+                "message": {
+                    "message_id": 100,
+                    "chat": {"id": 987654321},
+                    "text": "/search auth bug",
+                },
+            }
+        )
+
+        response = await router.handle_telegram_webhook(request)
+
+        assert response.status == 200
+        assert handler_called
+        assert handler_args[0] == "search"
+        assert handler_args[1] == "auth bug"
+        assert handler_args[2] == 987654321
+        assert handler_args[3] == 100
+
+    async def test_command_without_args(self, router: BotRouter) -> None:
+        """Route command without arguments."""
+        received_args: str | None = None
+
+        async def handler(command: str, args: str, chat_id: int, message_id: int) -> None:
+            nonlocal received_args
+            received_args = args
+
+        router.register_telegram_command("search", handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "message": {
+                    "message_id": 1,
+                    "chat": {"id": 123},
+                    "text": "/search",
+                },
+            }
+        )
+
+        await router.handle_telegram_webhook(request)
+
+        assert received_args == ""
+
+    async def test_command_with_bot_mention(self, router: BotRouter) -> None:
+        """Handle /command@botname format in groups."""
+        received_command: str | None = None
+
+        async def handler(command: str, args: str, chat_id: int, message_id: int) -> None:
+            nonlocal received_command
+            received_command = command
+
+        router.register_telegram_command("search", handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "message": {
+                    "message_id": 1,
+                    "chat": {"id": 123},
+                    "text": "/search@mybot query",
+                },
+            }
+        )
+
+        await router.handle_telegram_webhook(request)
+
+        assert received_command == "search"
+
+    async def test_non_command_message_ignored(self, router: BotRouter) -> None:
+        """Non-command messages don't trigger handlers."""
+        handler_called = False
+
+        async def handler(command: str, args: str, chat_id: int, message_id: int) -> None:
+            nonlocal handler_called
+            handler_called = True
+
+        router.register_telegram_command("search", handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "message": {
+                    "message_id": 1,
+                    "chat": {"id": 123},
+                    "text": "Hello, this is not a command",
+                },
+            }
+        )
+
+        await router.handle_telegram_webhook(request)
+
+        assert not handler_called
+
+
+class TestTelegramCallbackQueryRouting:
+    """Tests for Telegram callback query routing."""
+
+    async def test_route_watch_callback(self, router: BotRouter) -> None:
+        """Route watch callback to registered handler."""
+        handler_called = False
+        handler_args: tuple = ()
+
+        async def watch_handler(
+            callback_data: str, chat_id: int, message_id: int, callback_query_id: str
+        ) -> None:
+            nonlocal handler_called, handler_args
+            handler_called = True
+            handler_args = (callback_data, chat_id, message_id, callback_query_id)
+
+        router.register_telegram_callback("w:", watch_handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123456789,
+                "callback_query": {
+                    "id": "callback123",
+                    "data": "w:0:abc123",
+                    "message": {
+                        "message_id": 100,
+                        "chat": {"id": 987654321},
+                    },
+                },
+            }
+        )
+
+        response = await router.handle_telegram_webhook(request)
+
+        assert response.status == 200
+        assert handler_called
+        assert handler_args[0] == "w:0:abc123"
+        assert handler_args[1] == 987654321
+        assert handler_args[2] == 100
+        assert handler_args[3] == "callback123"
+
+    async def test_route_preview_callback(self, router: BotRouter) -> None:
+        """Route preview callback to different handler."""
+        watch_called = False
+        preview_called = False
+
+        async def watch_handler(
+            callback_data: str, chat_id: int, message_id: int, callback_query_id: str
+        ) -> None:
+            nonlocal watch_called
+            watch_called = True
+
+        async def preview_handler(
+            callback_data: str, chat_id: int, message_id: int, callback_query_id: str
+        ) -> None:
+            nonlocal preview_called
+            preview_called = True
+
+        router.register_telegram_callback("w:", watch_handler)
+        router.register_telegram_callback("p:", preview_handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "callback_query": {
+                    "id": "cb1",
+                    "data": "p:1:def456",
+                    "message": {"message_id": 1, "chat": {"id": 123}},
+                },
+            }
+        )
+
+        await router.handle_telegram_webhook(request)
+
+        assert not watch_called
+        assert preview_called
+
+    async def test_no_handler_still_returns_200(self, router: BotRouter) -> None:
+        """Unknown callback data still returns 200."""
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "callback_query": {
+                    "id": "cb1",
+                    "data": "unknown:action",
+                    "message": {"message_id": 1, "chat": {"id": 123}},
+                },
+            }
+        )
+
+        response = await router.handle_telegram_webhook(request)
+
+        assert response.status == 200
+
+
+class TestTelegramInvalidPayload:
+    """Tests for Telegram webhook with invalid payloads."""
+
+    async def test_invalid_json(self, router: BotRouter) -> None:
+        """Invalid JSON returns 200 (Telegram expects this)."""
+        request = MockRequest(_json_error=True)
+
+        response = await router.handle_telegram_webhook(request)
+
+        # Telegram expects 200 even on errors
+        assert response.status == 200
+
+    async def test_empty_update(self, router: BotRouter) -> None:
+        """Empty update object returns 200."""
+        request = MockRequest(_json_data={"update_id": 123})
+
+        response = await router.handle_telegram_webhook(request)
+
+        assert response.status == 200
+
+
+# --- Tests for _parse_form_data ---
+
+
+class TestParseFormData:
+    """Tests for form data parsing."""
+
+    def test_simple_fields(self) -> None:
+        """Parse simple URL-encoded fields."""
+        data = "key1=value1&key2=value2"
+
+        result = _parse_form_data(data)
+
+        assert result["key1"] == "value1"
+        assert result["key2"] == "value2"
+
+    def test_url_encoded_values(self) -> None:
+        """Parse URL-encoded special characters."""
+        data = "text=auth+bug&url=https%3A%2F%2Fexample.com"
+
+        result = _parse_form_data(data)
+
+        assert result["text"] == "auth bug"
+        assert result["url"] == "https://example.com"
+
+    def test_empty_value(self) -> None:
+        """Parse field with empty value."""
+        data = "empty=&filled=value"
+
+        result = _parse_form_data(data)
+
+        assert result["empty"] == ""
+        assert result["filled"] == "value"
+
+
+# --- Tests for register_bot_routes ---
+
+
+class TestRegisterBotRoutes:
+    """Tests for route registration."""
+
+    def test_registers_all_routes(self, router: BotRouter) -> None:
+        """Registers all three bot webhook routes."""
+        from aiohttp import web
+
+        app = web.Application()
+
+        register_bot_routes(app, router)
+
+        routes = {r.resource.canonical for r in app.router.routes() if r.resource}
+        assert "/slack/commands" in routes
+        assert "/slack/interactions" in routes
+        assert "/telegram/webhook" in routes
+
+
+# --- Tests for handler error handling ---
+
+
+class TestHandlerErrorHandling:
+    """Tests for error handling in handlers."""
+
+    async def test_slack_command_handler_exception(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Handler exception still returns 200 for Slack."""
+        async def bad_handler(
+            command: str, text: str, user_id: str, channel_id: str, response_url: str
+        ) -> None:
+            raise RuntimeError("Handler crashed")
+
+        router.register_slack_command("/search", bad_handler)
+
+        body = "command=%2Fsearch&text=test"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        # Should not raise, returns 200 to acknowledge
+        response = await router.handle_slack_command(request)
+        assert response.status == 200
+
+    async def test_telegram_command_handler_exception(self, router: BotRouter) -> None:
+        """Handler exception still returns 200 for Telegram."""
+        async def bad_handler(
+            command: str, args: str, chat_id: int, message_id: int
+        ) -> None:
+            raise RuntimeError("Handler crashed")
+
+        router.register_telegram_command("search", bad_handler)
+
+        request = MockRequest(
+            _json_data={
+                "update_id": 123,
+                "message": {
+                    "message_id": 1,
+                    "chat": {"id": 123},
+                    "text": "/search test",
+                },
+            }
+        )
+
+        # Should not raise, returns 200 to acknowledge
+        response = await router.handle_telegram_webhook(request)
+        assert response.status == 200
+
+    async def test_slack_interaction_handler_exception(
+        self, router: BotRouter, current_timestamp: str
+    ) -> None:
+        """Interaction handler exception still returns 200."""
+        async def bad_handler(
+            action_id: str, value: str | None, payload: dict
+        ) -> None:
+            raise RuntimeError("Handler crashed")
+
+        router.register_slack_interaction("watch:", bad_handler)
+
+        payload = {
+            "type": "block_actions",
+            "actions": [{"action_id": "watch:test", "value": "x"}],
+        }
+        body = f"payload={json.dumps(payload)}"
+        signature = make_slack_signature(
+            body, current_timestamp, router.bot_config.slack_signing_secret
+        )
+
+        request = MockRequest(
+            headers={
+                "X-Slack-Request-Timestamp": current_timestamp,
+                "X-Slack-Signature": signature,
+            },
+            _body=body.encode(),
+        )
+
+        response = await router.handle_slack_interaction(request)
+        assert response.status == 200
+
+
+# --- Tests for handler registration ---
+
+
+class TestHandlerRegistration:
+    """Tests for handler registration methods."""
+
+    def test_register_multiple_slack_commands(self, router: BotRouter) -> None:
+        """Can register multiple Slack commands."""
+        async def handler1(*args: Any) -> None:
+            pass
+
+        async def handler2(*args: Any) -> None:
+            pass
+
+        router.register_slack_command("/search", handler1)
+        router.register_slack_command("/projects", handler2)
+
+        assert "/search" in router._slack_command_handlers
+        assert "/projects" in router._slack_command_handlers
+
+    def test_register_multiple_telegram_commands(self, router: BotRouter) -> None:
+        """Can register multiple Telegram commands."""
+        async def handler1(*args: Any) -> None:
+            pass
+
+        async def handler2(*args: Any) -> None:
+            pass
+
+        router.register_telegram_command("search", handler1)
+        router.register_telegram_command("projects", handler2)
+
+        assert "search" in router._telegram_command_handlers
+        assert "projects" in router._telegram_command_handlers
+
+    def test_overwrite_handler(self, router: BotRouter) -> None:
+        """Registering same command overwrites previous handler."""
+        async def handler1(*args: Any) -> None:
+            pass
+
+        async def handler2(*args: Any) -> None:
+            pass
+
+        router.register_slack_command("/search", handler1)
+        router.register_slack_command("/search", handler2)
+
+        assert router._slack_command_handlers["/search"] is handler2


### PR DESCRIPTION
## Summary
- Add `BotRouter` component that receives incoming webhooks from Slack and Telegram and routes them to appropriate handlers
- Add Slack signature verification (HMAC-SHA256 with timestamp validation)
- Add `slack_signing_secret` field to `BotConfig` for signature verification
- Add 40 comprehensive unit tests

## Test plan
- [x] Unit test: Slack signature verification (valid)
- [x] Unit test: Slack signature verification (invalid)
- [x] Unit test: Slack signature verification (expired timestamp)
- [x] Unit test: Route /search command correctly
- [x] Unit test: Route button interaction correctly
- [x] Unit test: Telegram webhook parses message command
- [x] Unit test: Telegram webhook parses callback query

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)