### PR TITLE
Issue #110: Add aiosqlite dependency for search index

### DIFF
--- a/issues/worklogs/110-worklog.md
+++ b/issues/worklogs/110-worklog.md
@@ -1,0 +1,62 @@
+# Issue #110: Add aiosqlite dependency for search index
+
+## Summary
+
+Added `aiosqlite>=0.19.0` as a dependency for the SQLite-based search index to the `watcher` optional dependencies.
+
+## Changes Made
+
+### Modified Files
+
+1. **`pyproject.toml`**
+   - Added `aiosqlite>=0.19.0` to the `watcher` optional dependencies
+   - Full dependency list now: `["pyyaml>=6.0", "watchfiles>=0.21", "aiohttp>=3.0", "aiosqlite>=0.19.0"]`
+
+## Version Selection Rationale
+
+- `aiosqlite>=0.19.0`: Stable async SQLite wrapper, supports Python 3.8+
+- No upper bound: Allow minor/patch updates
+- 0.19.0 minimum: Includes `backup()` method needed for database backups per the spec
+
+## Verification
+
+1. **Installation verified:**
+   ```
+   $ uv pip install -e ".[watcher]"
+   + aiosqlite==0.22.1
+   ```
+
+2. **Import verified:**
+   ```python
+   $ python -c "import aiosqlite; print(f'aiosqlite version: {aiosqlite.__version__}')"
+   aiosqlite version: 0.22.1
+   ```
+
+3. **All tests pass:** 1582 passed
+
+## README Update
+
+Not needed. The README already instructs users to install with `pip install "claude-session-player[watcher]"` which automatically includes all watcher dependencies including the new `aiosqlite` package.
+
+## CI Update
+
+Not applicable. No CI configuration exists in this project yet.
+
+## Definition of Done Status
+
+- [x] Dependency added to pyproject.toml
+- [x] Installation verified locally (`pip install -e ".[watcher]"` succeeds)
+- [x] Import works (`import aiosqlite` succeeds)
+- [x] All tests pass (1582 passed)
+- [x] README updated if needed (not needed - users already instructed to use `[watcher]` extras)
+- [x] CI passes (N/A - no CI configured)
+
+## Spec Reference
+
+This issue implements the "Dependencies" section from `.claude/specs/sqlite-search-index.md` (lines 1553-1575):
+- Required: `aiosqlite>=0.19.0` - Async SQLite wrapper
+
+## Blocks
+
+This unblocks:
+- SearchDatabase core implementation (issue #111)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ messaging = [
 ]
 slack = ["slack-sdk>=3.0", "aiohttp>=3.0"]
 telegram = ["python-telegram-bot>=21.0"]
-watcher = ["pyyaml>=6.0", "watchfiles>=0.21", "aiohttp>=3.0"]
+watcher = ["pyyaml>=6.0", "watchfiles>=0.21", "aiohttp>=3.0", "aiosqlite>=0.19.0"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Add `aiosqlite>=0.19.0` to the `watcher` optional dependencies for the SQLite-based search index.

## Changes

- Added `aiosqlite>=0.19.0` to `watcher` optional dependencies in `pyproject.toml`

## Verification

- [x] `pip install -e ".[watcher]"` succeeds
- [x] `import aiosqlite` works
- [x] All 1582 tests pass

## Test plan

- [x] Run `pip install -e ".[watcher]"` - dependency is installed
- [x] Run `python -c "import aiosqlite"` - import succeeds
- [x] Run `pytest` - all tests pass

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)