### PR TITLE
Issue #145: Add Telegram supergroup topic support

### DIFF
--- a/claude_session_player/watcher/__init__.py
+++ b/claude_session_player/watcher/__init__.py
@@ -27,7 +27,12 @@ from claude_session_player.watcher.search_db import (
 from claude_session_player.watcher.indexer import SQLiteSessionIndexer
 from claude_session_player.watcher.debouncer import MessageDebouncer, PendingUpdate
 from claude_session_player.watcher.deps import check_slack_available, check_telegram_available
-from claude_session_player.watcher.destinations import AttachedDestination, DestinationManager
+from claude_session_player.watcher.destinations import (
+    AttachedDestination,
+    DestinationManager,
+    make_telegram_identifier,
+    parse_telegram_identifier,
+)
 from claude_session_player.watcher.event_buffer import EventBuffer, EventBufferManager
 from claude_session_player.watcher.file_watcher import FileWatcher, IncrementalReader
 from claude_session_player.watcher.message_state import (
@@ -107,6 +112,7 @@ __all__ = [
     "format_question_text",
     "IndexConfig",
     "IndexedSession",
+    "make_telegram_identifier",
     "MAX_QUESTION_BUTTONS",
     "migrate_config",
     "delete_telegram_webhook",
@@ -161,6 +167,7 @@ __all__ = [
     "TelegramBotState",
     "TelegramDestination",
     "TelegramError",
+    "parse_telegram_identifier",
     "TelegramPollingRunner",
     "TelegramPublisher",
     "ToolCallInfo",

--- a/claude_session_player/watcher/telegram_publisher.py
+++ b/claude_session_player/watcher/telegram_publisher.py
@@ -332,14 +332,16 @@ class TelegramPublisher:
         text: str,
         parse_mode: str = "Markdown",
         reply_markup: InlineKeyboardMarkup | None = None,
+        message_thread_id: int | None = None,
     ) -> int:
-        """Send a new message to a chat.
+        """Send a new message to a chat or topic.
 
         Args:
             chat_id: Telegram chat ID.
             text: Message text (Markdown formatted).
             parse_mode: Telegram parse mode (default "Markdown").
             reply_markup: Optional inline keyboard markup.
+            message_thread_id: Topic thread ID for supergroups with topics.
 
         Returns:
             message_id of the sent message.
@@ -361,6 +363,7 @@ class TelegramPublisher:
                 text=text,
                 parse_mode=parse_mode,
                 reply_markup=reply_markup,
+                message_thread_id=message_thread_id,
             )
             return result.message_id
         except TelegramAPIError:
@@ -372,6 +375,7 @@ class TelegramPublisher:
                     text=text,
                     parse_mode=parse_mode,
                     reply_markup=reply_markup,
+                    message_thread_id=message_thread_id,
                 )
                 return result.message_id
             except TelegramAPIError as e2:

--- a/issues/worklogs/145-worklog.md
+++ b/issues/worklogs/145-worklog.md
@@ -1,0 +1,186 @@
+# Issue #145: Telegram supergroup topic support
+
+## Summary
+
+Added support for Telegram supergroup topics (forums), allowing each topic to receive a dedicated Claude session stream. This feature uses the `message_thread_id` parameter in the Telegram Bot API to target specific topics within a supergroup.
+
+## Design Decisions
+
+Based on the spec in `.claude/specs/telegram-topic-support.md`:
+
+1. **Compound Identifier** - Combined `chat_id:thread_id` format (e.g., `-1001234567890:123`) for internal identifier tracking
+2. **Reject thread_id=1** - Prevents duplicate identifiers since General topic is accessed with thread_id=null
+3. **Exact Match Detach** - Must specify exact thread_id to detach a destination
+4. **Single Source of Truth** - `TelegramDestination.identifier` property delegates to helper functions
+
+## Changes Made
+
+### 1. Config Module (claude_session_player/watcher/config.py)
+
+- Added `thread_id: int | None = None` field to `TelegramDestination`
+- Added `identifier` property that uses `make_telegram_identifier()` helper
+- Updated `to_dict()` to include thread_id when set
+- Updated `from_dict()` to parse thread_id from config
+- Updated `add_destination()` and `remove_destination()` to match by full identifier
+
+### 2. Destinations Module (claude_session_player/watcher/destinations.py)
+
+Added helper functions for compound identifier handling:
+
+- `make_telegram_identifier(chat_id, thread_id)` - Creates `chat_id:thread_id` format
+- `parse_telegram_identifier(identifier)` - Parses using `rsplit(":", 1)` to handle negative chat_ids
+
+Updated `attach()`, `detach()`, and `restore_from_config()` to use parsed identifiers.
+
+### 3. Telegram Publisher (claude_session_player/watcher/telegram_publisher.py)
+
+- Added `message_thread_id: int | None = None` parameter to `send_message()`
+- Passes `message_thread_id` to aiogram `Bot.send_message()` calls
+
+### 4. REST API (claude_session_player/watcher/api.py)
+
+- Updated `handle_attach()` to accept `thread_id` in destination payload
+- Added validation to reject `thread_id=1` with error message
+- Updated `handle_detach()` to parse and use thread_id for exact match
+- Updated `handle_list_sessions()` to include thread_id in response
+
+### 5. Bot Router (claude_session_player/watcher/bot_router.py)
+
+- Updated type aliases to include thread_id parameter:
+  - `TelegramCommandHandler` - Added Optional[int] for thread_id
+  - `TelegramCallbackHandler` - Added Optional[int] for thread_id
+- Extract `message_thread_id` from Telegram message and callback_query updates
+- Pass thread_id to all handler calls
+
+### 6. Telegram Commands (claude_session_player/watcher/telegram_commands.py)
+
+- Updated `handle_search()` to accept thread_id and use compound identifier for state key
+- Updated `handle_callback()` and all `_handle_*` methods to accept and pass thread_id
+- Store thread_id in search state for use in Watch action callbacks
+- Updated helper methods `_send_message_with_keyboard()` and `_send_reply()` to accept thread_id
+
+### 7. Watcher Service (claude_session_player/watcher/service.py)
+
+- Updated `_send_new_message()` to parse identifier and pass thread_id to publisher
+- Updated `replay_to_destination()` to parse identifier and pass thread_id
+
+### 8. Package Exports (claude_session_player/watcher/__init__.py)
+
+- Added exports for `make_telegram_identifier` and `parse_telegram_identifier`
+
+## Tests Added
+
+### New Test File (tests/watcher/test_telegram_topic.py)
+
+33 tests covering:
+
+**Identifier Helper Tests (11 tests):**
+- `TestMakeTelegramIdentifier` - 5 tests for make_telegram_identifier()
+- `TestParseTelegramIdentifier` - 6 tests for parse_telegram_identifier()
+
+**TelegramDestination Tests (8 tests):**
+- `TestTelegramDestinationIdentifier` - 3 tests for identifier property
+- `TestTelegramDestinationSerialization` - 5 tests for to_dict/from_dict roundtrip
+
+**Destination Manager Tests (7 tests):**
+- `TestAttachWithThreadId` - 3 tests for attach with thread_id
+- `TestDetachWithThreadId` - 2 tests for detach exact match behavior
+- `TestRestoreFromConfigWithThreadId` - 1 test for config restoration
+
+**Module Import Tests (2 tests):**
+- Test importing helpers from destinations module
+- Test importing helpers from watcher package
+
+**Integration Tests (3 tests):**
+- `TestSendMessageToTopic` - Message sending includes thread_id
+- Tests for replay_to_destination with thread_id
+
+**API Tests (3 tests):**
+- `TestAPIThreadIdValidation` - Tests for thread_id=1 rejection and valid thread_id acceptance
+- Test for list_sessions including thread_id in response
+
+### Updated Test Files
+
+- `tests/watcher/test_api.py` - Updated error message assertion for missing identifier
+- `tests/watcher/test_bot_router.py` - Updated handler signatures to include thread_id
+- `tests/watcher/test_telegram_commands.py` - Updated callback test assertions for thread_id
+- `tests/watcher/test_telegram_publisher.py` - Updated send_message assertions for message_thread_id
+- `tests/watcher/test_messaging_integration.py` - Updated MockTelegramPublisher signature
+- `tests/watcher/test_messaging_e2e.py` - Updated MockTelegramBot signature
+
+## API Changes
+
+### POST /attach
+
+Request body now accepts `thread_id`:
+```json
+{
+  "session_id": "my-session",
+  "path": "/path/to/session.jsonl",
+  "destination": {
+    "type": "telegram",
+    "chat_id": "-1001234567890",
+    "thread_id": 123  // Optional
+  }
+}
+```
+
+Validation:
+- `thread_id=1` is rejected with 400 error (use null for General topic)
+
+### POST /detach
+
+Request body accepts `thread_id` for exact match:
+```json
+{
+  "session_id": "my-session",
+  "destination": {
+    "type": "telegram",
+    "chat_id": "-1001234567890",
+    "thread_id": 123  // Must match exactly
+  }
+}
+```
+
+### GET /sessions
+
+Response includes thread_id:
+```json
+{
+  "sessions": [{
+    "session_id": "my-session",
+    "destinations": {
+      "telegram": [{
+        "chat_id": "-1001234567890",
+        "thread_id": 123
+      }]
+    }
+  }]
+}
+```
+
+## Test Results
+
+All 2048 tests pass:
+```
+tests/watcher/test_telegram_topic.py: 33 passed
+Full test suite: 2048 passed in ~4 minutes
+```
+
+## Files Changed
+
+- `claude_session_player/watcher/__init__.py`
+- `claude_session_player/watcher/api.py`
+- `claude_session_player/watcher/bot_router.py`
+- `claude_session_player/watcher/config.py`
+- `claude_session_player/watcher/destinations.py`
+- `claude_session_player/watcher/service.py`
+- `claude_session_player/watcher/telegram_commands.py`
+- `claude_session_player/watcher/telegram_publisher.py`
+- `tests/watcher/test_api.py`
+- `tests/watcher/test_bot_router.py`
+- `tests/watcher/test_messaging_e2e.py`
+- `tests/watcher/test_messaging_integration.py`
+- `tests/watcher/test_telegram_commands.py`
+- `tests/watcher/test_telegram_publisher.py`
+- `tests/watcher/test_telegram_topic.py` (new)

--- a/tests/watcher/test_api.py
+++ b/tests/watcher/test_api.py
@@ -656,7 +656,8 @@ class TestHandleDetachValidationErrors:
 
         assert response.status == 400
         data = json.loads(response.body)
-        assert "identifier required" in data["error"].lower()
+        # Error message says "chat_id required" for telegram
+        assert "chat_id required" in data["error"].lower() or "identifier required" in data["error"].lower()
 
 
 class TestHandleDetachNotFound:

--- a/tests/watcher/test_messaging_e2e.py
+++ b/tests/watcher/test_messaging_e2e.py
@@ -69,7 +69,12 @@ class MockTelegramBot:
             raise TelegramError("Validation failed")
 
     async def send_message(
-        self, chat_id: str, text: str, parse_mode: str = "Markdown"
+        self,
+        chat_id: str,
+        text: str,
+        parse_mode: str = "Markdown",
+        reply_markup: object = None,
+        message_thread_id: int | None = None,
     ) -> int:
         """Send a message to a chat."""
         if self._should_fail_send:
@@ -81,6 +86,7 @@ class MockTelegramBot:
             "text": text,
             "message_id": message_id,
             "parse_mode": parse_mode,
+            "message_thread_id": message_thread_id,
         })
         return message_id
 

--- a/tests/watcher/test_messaging_integration.py
+++ b/tests/watcher/test_messaging_integration.py
@@ -65,7 +65,12 @@ class MockTelegramPublisher:
         self.validated = True
 
     async def send_message(
-        self, chat_id: str, text: str, parse_mode: str = "Markdown"
+        self,
+        chat_id: str,
+        text: str,
+        parse_mode: str = "Markdown",
+        reply_markup: object = None,
+        message_thread_id: int | None = None,
     ) -> int:
         if self._should_fail:
             raise TelegramError("Send failed")
@@ -75,6 +80,7 @@ class MockTelegramPublisher:
             "chat_id": chat_id,
             "text": text,
             "message_id": message_id,
+            "message_thread_id": message_thread_id,
         })
         return message_id
 

--- a/tests/watcher/test_telegram_commands.py
+++ b/tests/watcher/test_telegram_commands.py
@@ -978,56 +978,56 @@ class TestCallbackDataParsing:
         """Test parsing watch callback data."""
         mock_handle_watch = AsyncMock(return_value="result")
         with patch.object(handler, "_handle_watch", mock_handle_watch):
-            result = await handler.handle_callback("w:0", 123456, 789)
-        mock_handle_watch.assert_called_once_with("123456", 789, 0)
+            result = await handler.handle_callback("w:0", 123456, 789, thread_id=None)
+        mock_handle_watch.assert_called_once_with("123456", 789, 0, None)
 
     @pytest.mark.asyncio
     async def test_parse_preview_callback(self, handler: TelegramCommandHandler) -> None:
         """Test parsing preview callback data."""
         mock_handle_preview = AsyncMock(return_value="result")
         with patch.object(handler, "_handle_preview", mock_handle_preview):
-            result = await handler.handle_callback("p:2", 123456, 789)
-        mock_handle_preview.assert_called_once_with("123456", 789, 2)
+            result = await handler.handle_callback("p:2", 123456, 789, thread_id=None)
+        mock_handle_preview.assert_called_once_with("123456", 789, 2, None)
 
     @pytest.mark.asyncio
     async def test_parse_next_page_callback(self, handler: TelegramCommandHandler) -> None:
         """Test parsing next page callback data."""
         mock_handle_next = AsyncMock(return_value="result")
         with patch.object(handler, "_handle_next_page", mock_handle_next):
-            result = await handler.handle_callback("s:n", 123456, 789)
-        mock_handle_next.assert_called_once_with("123456", 789)
+            result = await handler.handle_callback("s:n", 123456, 789, thread_id=None)
+        mock_handle_next.assert_called_once_with("123456", 789, None)
 
     @pytest.mark.asyncio
     async def test_parse_prev_page_callback(self, handler: TelegramCommandHandler) -> None:
         """Test parsing prev page callback data."""
         mock_handle_prev = AsyncMock(return_value="result")
         with patch.object(handler, "_handle_prev_page", mock_handle_prev):
-            result = await handler.handle_callback("s:p", 123456, 789)
-        mock_handle_prev.assert_called_once_with("123456", 789)
+            result = await handler.handle_callback("s:p", 123456, 789, thread_id=None)
+        mock_handle_prev.assert_called_once_with("123456", 789, None)
 
     @pytest.mark.asyncio
     async def test_parse_refresh_callback(self, handler: TelegramCommandHandler) -> None:
         """Test parsing refresh callback data."""
         mock_handle_refresh = AsyncMock(return_value="result")
         with patch.object(handler, "_handle_refresh", mock_handle_refresh):
-            result = await handler.handle_callback("s:r", 123456, 789)
-        mock_handle_refresh.assert_called_once_with("123456", 789)
+            result = await handler.handle_callback("s:r", 123456, 789, thread_id=None)
+        mock_handle_refresh.assert_called_once_with("123456", 789, None)
 
     @pytest.mark.asyncio
     async def test_invalid_callback_data(self, handler: TelegramCommandHandler) -> None:
         """Test handling invalid callback data."""
         # Empty index (parts[1] is empty string)
-        result = await handler.handle_callback("w:", 123456, 789)
+        result = await handler.handle_callback("w:", 123456, 789, thread_id=None)
         assert result == "Invalid index"  # Empty string fails int conversion
 
         # Non-numeric index
-        result = await handler.handle_callback("w:abc", 123456, 789)
+        result = await handler.handle_callback("w:abc", 123456, 789, thread_id=None)
         assert result == "Invalid index"
 
         # Missing index entirely (no colon separator)
-        result = await handler.handle_callback("w", 123456, 789)
+        result = await handler.handle_callback("w", 123456, 789, thread_id=None)
         assert result == "Invalid action"
 
         # Unknown action
-        result = await handler.handle_callback("x:0", 123456, 789)
+        result = await handler.handle_callback("x:0", 123456, 789, thread_id=None)
         assert result is None

--- a/tests/watcher/test_telegram_publisher.py
+++ b/tests/watcher/test_telegram_publisher.py
@@ -423,6 +423,7 @@ class TestTelegramPublisherSendMessage:
             text="Hello world",
             parse_mode="Markdown",
             reply_markup=None,
+            message_thread_id=None,
         )
 
     @pytest.mark.asyncio
@@ -540,6 +541,7 @@ class TestTelegramPublisherSendMessage:
             text="Choose an option",
             parse_mode="Markdown",
             reply_markup=keyboard,
+            message_thread_id=None,
         )
 
 

--- a/tests/watcher/test_telegram_topic.py
+++ b/tests/watcher/test_telegram_topic.py
@@ -1,0 +1,844 @@
+"""Tests for Telegram supergroup topic support."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from claude_session_player.watcher.config import (
+    ConfigManager,
+    SessionConfig,
+    SessionDestinations,
+    TelegramDestination,
+)
+from claude_session_player.watcher.destinations import (
+    AttachedDestination,
+    DestinationManager,
+    make_telegram_identifier,
+    parse_telegram_identifier,
+)
+
+
+# ---------------------------------------------------------------------------
+# Identifier Helper Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeTelegramIdentifier:
+    """Tests for make_telegram_identifier helper."""
+
+    def test_without_thread_id(self) -> None:
+        """Returns chat_id when no thread_id."""
+        result = make_telegram_identifier("123456789")
+        assert result == "123456789"
+
+    def test_with_thread_id(self) -> None:
+        """Returns chat_id:thread_id format when thread_id provided."""
+        result = make_telegram_identifier("123456789", 456)
+        assert result == "123456789:456"
+
+    def test_negative_chat_id(self) -> None:
+        """Handles negative chat_ids correctly."""
+        result = make_telegram_identifier("-1001234567890")
+        assert result == "-1001234567890"
+
+    def test_negative_chat_id_with_thread_id(self) -> None:
+        """Handles negative chat_ids with thread_id."""
+        result = make_telegram_identifier("-1001234567890", 123)
+        assert result == "-1001234567890:123"
+
+    def test_thread_id_none_explicit(self) -> None:
+        """Explicitly passing None for thread_id returns just chat_id."""
+        result = make_telegram_identifier("123", None)
+        assert result == "123"
+
+
+class TestParseTelegramIdentifier:
+    """Tests for parse_telegram_identifier helper."""
+
+    def test_simple_chat_id(self) -> None:
+        """Parses simple chat_id without colon."""
+        chat_id, thread_id = parse_telegram_identifier("123456789")
+        assert chat_id == "123456789"
+        assert thread_id is None
+
+    def test_chat_id_with_thread_id(self) -> None:
+        """Parses chat_id:thread_id format."""
+        chat_id, thread_id = parse_telegram_identifier("123456789:456")
+        assert chat_id == "123456789"
+        assert thread_id == 456
+
+    def test_negative_chat_id(self) -> None:
+        """Parses negative chat_id correctly."""
+        chat_id, thread_id = parse_telegram_identifier("-1001234567890")
+        assert chat_id == "-1001234567890"
+        assert thread_id is None
+
+    def test_negative_chat_id_with_thread_id(self) -> None:
+        """Parses negative chat_id with thread_id using rsplit."""
+        chat_id, thread_id = parse_telegram_identifier("-1001234567890:123")
+        assert chat_id == "-1001234567890"
+        assert thread_id == 123
+
+    def test_invalid_thread_id_returns_full_string(self) -> None:
+        """Invalid thread_id (non-integer) returns original identifier."""
+        chat_id, thread_id = parse_telegram_identifier("123:abc")
+        assert chat_id == "123:abc"
+        assert thread_id is None
+
+    def test_roundtrip(self) -> None:
+        """make and parse are inverses."""
+        original_chat = "-1001234567890"
+        original_thread = 456
+
+        identifier = make_telegram_identifier(original_chat, original_thread)
+        parsed_chat, parsed_thread = parse_telegram_identifier(identifier)
+
+        assert parsed_chat == original_chat
+        assert parsed_thread == original_thread
+
+
+# ---------------------------------------------------------------------------
+# TelegramDestination Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramDestinationIdentifier:
+    """Tests for TelegramDestination.identifier property."""
+
+    def test_identifier_without_thread_id(self) -> None:
+        """identifier returns just chat_id when no thread_id."""
+        dest = TelegramDestination(chat_id="123456789")
+        assert dest.identifier == "123456789"
+
+    def test_identifier_with_thread_id(self) -> None:
+        """identifier returns combined format when thread_id set."""
+        dest = TelegramDestination(chat_id="123456789", thread_id=456)
+        assert dest.identifier == "123456789:456"
+
+    def test_identifier_with_negative_chat_id(self) -> None:
+        """identifier handles negative chat_id."""
+        dest = TelegramDestination(chat_id="-1001234567890", thread_id=123)
+        assert dest.identifier == "-1001234567890:123"
+
+
+class TestTelegramDestinationSerialization:
+    """Tests for TelegramDestination to_dict/from_dict."""
+
+    def test_to_dict_without_thread_id(self) -> None:
+        """to_dict omits thread_id when None."""
+        dest = TelegramDestination(chat_id="123")
+        d = dest.to_dict()
+        assert d == {"chat_id": "123"}
+        assert "thread_id" not in d
+
+    def test_to_dict_with_thread_id(self) -> None:
+        """to_dict includes thread_id when set."""
+        dest = TelegramDestination(chat_id="123", thread_id=456)
+        d = dest.to_dict()
+        assert d == {"chat_id": "123", "thread_id": 456}
+
+    def test_from_dict_without_thread_id(self) -> None:
+        """from_dict creates destination without thread_id."""
+        dest = TelegramDestination.from_dict({"chat_id": "123"})
+        assert dest.chat_id == "123"
+        assert dest.thread_id is None
+
+    def test_from_dict_with_thread_id(self) -> None:
+        """from_dict creates destination with thread_id."""
+        dest = TelegramDestination.from_dict({"chat_id": "123", "thread_id": 456})
+        assert dest.chat_id == "123"
+        assert dest.thread_id == 456
+
+    def test_roundtrip_serialization(self) -> None:
+        """to_dict and from_dict are inverses."""
+        original = TelegramDestination(chat_id="-1001234567890", thread_id=123)
+        d = original.to_dict()
+        restored = TelegramDestination.from_dict(d)
+        assert restored.chat_id == original.chat_id
+        assert restored.thread_id == original.thread_id
+        assert restored.identifier == original.identifier
+
+
+# ---------------------------------------------------------------------------
+# Destination Manager with Thread ID Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_config_manager(tmp_path: Path) -> MagicMock:
+    """Create a mock ConfigManager."""
+    config = MagicMock(spec=ConfigManager)
+    config.get.return_value = None
+    config.load.return_value = []
+    config.add_destination.return_value = True
+    config.remove_destination.return_value = True
+    return config
+
+
+@pytest.fixture
+def on_session_start() -> AsyncMock:
+    """Create async mock for on_session_start callback."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def on_session_stop() -> AsyncMock:
+    """Create async mock for on_session_stop callback."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def destination_manager(
+    mock_config_manager: MagicMock,
+    on_session_start: AsyncMock,
+    on_session_stop: AsyncMock,
+) -> DestinationManager:
+    """Create a DestinationManager with mocks."""
+    return DestinationManager(
+        _config=mock_config_manager,
+        _on_session_start=on_session_start,
+        _on_session_stop=on_session_stop,
+        _keep_alive_seconds=1,
+    )
+
+
+@pytest.fixture
+def session_jsonl(tmp_path: Path) -> Path:
+    """Create a temporary JSONL session file."""
+    session_file = tmp_path / "session.jsonl"
+    session_file.write_text('{"type": "user"}\n')
+    return session_file
+
+
+class TestAttachWithThreadId:
+    """Tests for attaching destinations with thread_id."""
+
+    @pytest.mark.asyncio
+    async def test_attach_with_thread_id(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Attach with compound identifier containing thread_id."""
+        identifier = make_telegram_identifier("-1001234567890", 123)
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=identifier,
+        )
+
+        # Verify config was updated with correct TelegramDestination
+        mock_config_manager.add_destination.assert_called_once()
+        call_args = mock_config_manager.add_destination.call_args
+        config_dest = call_args[0][1]
+        assert isinstance(config_dest, TelegramDestination)
+        assert config_dest.chat_id == "-1001234567890"
+        assert config_dest.thread_id == 123
+
+    @pytest.mark.asyncio
+    async def test_different_threads_are_separate_destinations(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Same chat_id with different thread_ids are separate destinations."""
+        # Attach to topic 123
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 123),
+        )
+
+        # Attach to topic 456 (same chat, different topic)
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 456),
+        )
+
+        # Both should be tracked separately
+        destinations = destination_manager.get_destinations("test-session")
+        assert len(destinations) == 2
+        identifiers = [d.identifier for d in destinations]
+        assert "-1001234567890:123" in identifiers
+        assert "-1001234567890:456" in identifiers
+
+    @pytest.mark.asyncio
+    async def test_attach_idempotent_with_same_thread(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Attaching same chat_id:thread_id is idempotent."""
+        identifier = make_telegram_identifier("-1001234567890", 123)
+
+        result1 = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=identifier,
+        )
+
+        result2 = await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=identifier,
+        )
+
+        assert result1 is True
+        assert result2 is False  # Idempotent
+
+        destinations = destination_manager.get_destinations("test-session")
+        assert len(destinations) == 1
+
+
+class TestDetachWithThreadId:
+    """Tests for detaching destinations with thread_id."""
+
+    @pytest.mark.asyncio
+    async def test_detach_exact_thread_match(
+        self,
+        destination_manager: DestinationManager,
+        mock_config_manager: MagicMock,
+        session_jsonl: Path,
+    ) -> None:
+        """Detach requires exact thread_id match."""
+        # Attach to topic 123
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 123),
+        )
+
+        # Try to detach without thread_id - should fail
+        result = await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier="-1001234567890",  # No thread_id
+        )
+        assert result is False
+
+        # Detach with correct thread_id - should succeed
+        result = await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 123),
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_detach_different_thread_fails(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Detaching with wrong thread_id fails."""
+        # Attach to topic 123
+        await destination_manager.attach(
+            session_id="test-session",
+            path=session_jsonl,
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 123),
+        )
+
+        # Try to detach topic 456 - should fail
+        result = await destination_manager.detach(
+            session_id="test-session",
+            destination_type="telegram",
+            identifier=make_telegram_identifier("-1001234567890", 456),
+        )
+        assert result is False
+
+        # Original destination still exists
+        destinations = destination_manager.get_destinations("test-session")
+        assert len(destinations) == 1
+
+
+class TestRestoreFromConfigWithThreadId:
+    """Tests for restore_from_config with thread_id."""
+
+    @pytest.mark.asyncio
+    async def test_restore_preserves_thread_id(
+        self,
+        mock_config_manager: MagicMock,
+        on_session_start: AsyncMock,
+        on_session_stop: AsyncMock,
+        session_jsonl: Path,
+    ) -> None:
+        """restore_from_config preserves thread_id in identifier."""
+        mock_config_manager.load.return_value = [
+            SessionConfig(
+                session_id="session-1",
+                path=session_jsonl,
+                destinations=SessionDestinations(
+                    telegram=[
+                        TelegramDestination(chat_id="-1001234567890", thread_id=123),
+                        TelegramDestination(chat_id="-1001234567890", thread_id=456),
+                    ],
+                    slack=[],
+                ),
+            ),
+        ]
+
+        manager = DestinationManager(
+            _config=mock_config_manager,
+            _on_session_start=on_session_start,
+            _on_session_stop=on_session_stop,
+        )
+
+        await manager.restore_from_config()
+
+        destinations = manager.get_destinations("session-1")
+        assert len(destinations) == 2
+        identifiers = [d.identifier for d in destinations]
+        assert "-1001234567890:123" in identifiers
+        assert "-1001234567890:456" in identifiers
+
+
+# ---------------------------------------------------------------------------
+# Module Imports Tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    """Tests for module imports."""
+
+    def test_import_helpers_from_destinations(self) -> None:
+        """Can import identifier helpers from destinations module."""
+        from claude_session_player.watcher.destinations import (
+            make_telegram_identifier,
+            parse_telegram_identifier,
+        )
+
+        assert callable(make_telegram_identifier)
+        assert callable(parse_telegram_identifier)
+
+    def test_import_helpers_from_watcher_package(self) -> None:
+        """Can import identifier helpers from watcher package."""
+        from claude_session_player.watcher import (
+            make_telegram_identifier,
+            parse_telegram_identifier,
+        )
+
+        assert callable(make_telegram_identifier)
+        assert callable(parse_telegram_identifier)
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests: Message Sending to Topics
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockTelegramPublisherWithThreads:
+    """Mock TelegramPublisher that tracks message_thread_id."""
+
+    token: str | None = None
+    validated: bool = False
+    sent_messages: list[dict] = field(default_factory=list)
+    edited_messages: list[dict] = field(default_factory=list)
+    _next_message_id: int = field(default=1, repr=False)
+
+    async def validate(self) -> None:
+        self.validated = True
+
+    async def send_message(
+        self,
+        chat_id: str,
+        text: str,
+        parse_mode: str = "Markdown",
+        reply_markup: object = None,
+        message_thread_id: int | None = None,
+    ) -> int:
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        self.sent_messages.append({
+            "chat_id": chat_id,
+            "text": text,
+            "message_id": message_id,
+            "message_thread_id": message_thread_id,
+        })
+        return message_id
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: int,
+        text: str,
+        parse_mode: str = "Markdown",
+        reply_markup: object = None,
+    ) -> bool:
+        self.edited_messages.append({
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": text,
+        })
+        return True
+
+    async def close(self) -> None:
+        pass
+
+
+class TestSendMessageToTopic:
+    """Integration tests for sending messages to Telegram topics."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_includes_thread_id(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Messages sent to topic destination include thread_id."""
+        from claude_session_player.watcher.config import BotConfig, ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+
+        # Create temporary config
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        config_manager._bot_config = BotConfig(telegram_token="test-token")
+
+        mock_publisher = MockTelegramPublisherWithThreads(token="test-token")
+
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            telegram_publisher=mock_publisher,
+            port=18080,
+        )
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_jsonl)
+
+            # Attach to a topic (thread_id=123)
+            identifier = make_telegram_identifier("-1001234567890", 123)
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_jsonl,
+                destination_type="telegram",
+                identifier=identifier,
+            )
+
+            # Send a user block event
+            from claude_session_player.events import (
+                AddBlock,
+                Block,
+                BlockType,
+                UserContent,
+            )
+
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello from topic!"),
+            )
+            await service._publish_to_messaging("test-session", AddBlock(block=user_block))
+
+            # Verify message was sent with thread_id
+            assert len(mock_publisher.sent_messages) == 1
+            msg = mock_publisher.sent_messages[0]
+            assert msg["chat_id"] == "-1001234567890"
+            assert msg["message_thread_id"] == 123
+
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_send_message_without_thread_id(
+        self,
+        destination_manager: DestinationManager,
+        session_jsonl: Path,
+    ) -> None:
+        """Messages sent to chat without topic have thread_id=None."""
+        from claude_session_player.watcher.config import BotConfig, ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        config_manager._bot_config = BotConfig(telegram_token="test-token")
+
+        mock_publisher = MockTelegramPublisherWithThreads(token="test-token")
+
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            telegram_publisher=mock_publisher,
+            port=18081,
+        )
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_jsonl)
+
+            # Attach without thread_id
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_jsonl,
+                destination_type="telegram",
+                identifier="-1001234567890",
+            )
+
+            from claude_session_player.events import (
+                AddBlock,
+                Block,
+                BlockType,
+                UserContent,
+            )
+
+            user_block = Block(
+                id="user-1",
+                type=BlockType.USER,
+                content=UserContent(text="Hello from General!"),
+            )
+            await service._publish_to_messaging("test-session", AddBlock(block=user_block))
+
+            # Verify message was sent without thread_id
+            assert len(mock_publisher.sent_messages) == 1
+            msg = mock_publisher.sent_messages[0]
+            assert msg["chat_id"] == "-1001234567890"
+            assert msg["message_thread_id"] is None
+
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_replay_includes_thread_id(
+        self,
+        session_jsonl: Path,
+    ) -> None:
+        """Replay to topic destination includes thread_id."""
+        from claude_session_player.watcher.config import BotConfig, ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+        from claude_session_player.events import (
+            AddBlock,
+            Block,
+            BlockType,
+            UserContent,
+        )
+
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        config_manager._bot_config = BotConfig(telegram_token="test-token")
+
+        mock_publisher = MockTelegramPublisherWithThreads(token="test-token")
+
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            telegram_publisher=mock_publisher,
+            port=18082,
+        )
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_jsonl)
+
+            # Add events to buffer
+            for i in range(3):
+                user_block = Block(
+                    id=f"user-{i}",
+                    type=BlockType.USER,
+                    content=UserContent(text=f"Message {i}"),
+                )
+                service.event_buffer.add_event("test-session", AddBlock(block=user_block))
+
+            # Replay to topic
+            identifier = make_telegram_identifier("-1001234567890", 456)
+            replayed = await service.replay_to_destination(
+                session_id="test-session",
+                destination_type="telegram",
+                identifier=identifier,
+                count=3,
+            )
+
+            assert replayed == 3
+            assert len(mock_publisher.sent_messages) == 1
+            msg = mock_publisher.sent_messages[0]
+            assert msg["chat_id"] == "-1001234567890"
+            assert msg["message_thread_id"] == 456
+
+        finally:
+            await service.stop()
+
+
+# ---------------------------------------------------------------------------
+# API Endpoint Tests for Thread ID
+# ---------------------------------------------------------------------------
+
+
+class TestAPIThreadIdValidation:
+    """Tests for API endpoint thread_id handling."""
+
+    @pytest.mark.asyncio
+    async def test_attach_rejects_thread_id_1(self, session_jsonl: Path) -> None:
+        """API rejects thread_id=1 (reserved for General topic)."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from claude_session_player.watcher.config import ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            port=18083,
+        )
+
+        try:
+            await service.start()
+
+            # Build test app using the service's API
+            app = service.api.create_app()
+
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/attach",
+                    json={
+                        "session_id": "test-session",
+                        "path": str(session_jsonl),
+                        "destination": {
+                            "type": "telegram",
+                            "chat_id": "-1001234567890",
+                            "thread_id": 1,  # Should be rejected
+                        },
+                    },
+                )
+                assert resp.status == 400
+                data = await resp.json()
+                assert "thread_id=1" in data["error"] or "General" in data["error"]
+
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_attach_accepts_valid_thread_id(self, session_jsonl: Path) -> None:
+        """API accepts valid thread_id values."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from claude_session_player.watcher.config import BotConfig, ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        config_manager.set_bot_config(BotConfig(telegram_token="test-token"))
+
+        mock_publisher = MockTelegramPublisherWithThreads(token="test-token")
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            telegram_publisher=mock_publisher,
+            port=18084,
+        )
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_jsonl)
+
+            app = service.api.create_app()
+
+            # Mock the _validate_destination to skip actual API calls
+            with patch.object(service.api, "_validate_destination", new_callable=AsyncMock):
+                async with TestClient(TestServer(app)) as client:
+                    resp = await client.post(
+                        "/attach",
+                        json={
+                            "session_id": "test-session",
+                            "path": str(session_jsonl),
+                            "destination": {
+                                "type": "telegram",
+                                "chat_id": "-1001234567890",
+                                "thread_id": 123,
+                            },
+                        },
+                    )
+                    assert resp.status == 201  # 201 Created for new attachment
+                    data = await resp.json()
+                    assert data["attached"] is True
+
+        finally:
+            await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_includes_thread_id(self, session_jsonl: Path) -> None:
+        """GET /sessions response includes thread_id for topics."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from claude_session_player.watcher.config import BotConfig, ConfigManager
+        from claude_session_player.watcher.service import WatcherService
+
+        config_path = session_jsonl.parent / "config.yaml"
+        state_dir = session_jsonl.parent / "state"
+        state_dir.mkdir()
+
+        config_manager = ConfigManager(config_path)
+        config_manager.set_bot_config(BotConfig(telegram_token="test-token"))
+
+        mock_publisher = MockTelegramPublisherWithThreads(token="test-token")
+        service = WatcherService(
+            config_path=config_path,
+            state_dir=state_dir,
+            config_manager=config_manager,
+            telegram_publisher=mock_publisher,
+            port=18085,
+        )
+
+        try:
+            await service.start()
+            await service.watch("test-session", session_jsonl)
+
+            # Attach with thread_id
+            identifier = make_telegram_identifier("-1001234567890", 789)
+            await service.destination_manager.attach(
+                session_id="test-session",
+                path=session_jsonl,
+                destination_type="telegram",
+                identifier=identifier,
+            )
+
+            app = service.api.create_app()
+
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/sessions")
+                assert resp.status == 200
+                data = await resp.json()
+
+                session = data["sessions"][0]
+                tg_dest = session["destinations"]["telegram"][0]
+                assert tg_dest["chat_id"] == "-1001234567890"
+                assert tg_dest["thread_id"] == 789
+
+        finally:
+            await service.stop()


### PR DESCRIPTION
## Summary
Add support for Telegram supergroup topics (forums), allowing each topic to receive a dedicated Claude session stream. This feature uses the `message_thread_id` parameter in the Telegram Bot API to target specific topics within a supergroup.

## Changes
- Add `thread_id` field to `TelegramDestination` with `identifier` property
- Add `make_telegram_identifier`/`parse_telegram_identifier` helpers for compound identifier handling
- Add `message_thread_id` parameter to `TelegramPublisher.send_message()`
- Update REST API to accept/validate `thread_id`, reject `thread_id=1`
- Update bot router to extract `message_thread_id` from Telegram updates
- Update telegram commands to pass `thread_id` through handlers
- Update service to parse identifier and pass `thread_id` to publisher
- Add 33 comprehensive tests for topic support

## Design Decisions
- **Compound Identifier**: Use `chat_id:thread_id` format (e.g., `-1001234567890:123`)
- **Reject thread_id=1**: Prevents duplicate identifiers for General topic
- **Exact Match Detach**: Must specify exact `thread_id` to detach
- **Single Source of Truth**: `TelegramDestination.identifier` property delegates to helpers

## Test plan
- [x] Unit tests for identifier helpers (make/parse)
- [x] Tests for TelegramDestination serialization with thread_id
- [x] Tests for attach/detach with thread_id
- [x] Tests for restore_from_config preserving thread_id
- [x] Integration tests for message sending to topics
- [x] API tests for thread_id validation
- [x] Full test suite passes (2048 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)