### PR TITLE
Issue #166: Update documentation for new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,13 @@ claude-session-player index search "auth bug" --limit 10
 ├─────────────────────────────────────────────────────────────────┤
 │                      Watcher Service (Optional)                  │
 ├─────────────────────────────────────────────────────────────────┤
-│  ┌──────────┐    ┌───────────┐    ┌──────────────────────────┐ │
-│  │  File    │───▶│ Transform │───▶│  SSE  │  TG  │  Slack   │ │
-│  │ Watcher  │    │           │    └──────────────────────────┘ │
-│  └──────────┘    └───────────┘                                  │
+│  ┌──────────┐    ┌───────────┐    ┌───────────┐    ┌─────────┐ │
+│  │  File    │───▶│ Transform │───▶│  Render   │───▶│ Publish │ │
+│  │ Watcher  │    │           │    │  Cache    │    │ TG/Slack│ │
+│  └──────────┘    └───────────┘    └───────────┘    └─────────┘ │
+│                                          │                      │
+│                                          ▼                      │
+│                                    SSE + Search                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -214,11 +217,13 @@ Example: `/Users/me/my-project` → `-Users-me-my--project`
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/attach` | POST | Attach destination to session |
+| `/attach` | POST | Attach destination to session (requires `preset`: "desktop" or "mobile") |
 | `/detach` | POST | Detach destination |
 | `/sessions` | GET | List watched sessions |
 | `/sessions/{id}/events` | GET | SSE event stream |
 | `/search` | GET | Search sessions |
+| `/projects` | GET | List indexed projects |
+| `/index/refresh` | POST | Refresh search index |
 | `/health` | GET | Health check |
 
 See [API Reference](https://github.com/gutnikov/claude-session-player/wiki/API-Reference) for details.


### PR DESCRIPTION
## Summary
Update project documentation to reflect the new single-message rendering architecture.

## Changes

### CLAUDE.md
- Update watcher architecture diagram to show ScreenRenderer/RenderCache flow
- Update event flow diagram for new rendering model
- Replace MessageStateTracker with new components (ScreenRenderer, RenderCache, MessageBindingManager)
- Remove reference to deleted test_messaging_integration.py

### README.md
- Add `preset` parameter note to `/attach` endpoint (required: "desktop" or "mobile")
- Add missing endpoints to API reference (`/projects`, `/index/refresh`)
- Update architecture diagram to show Render Cache in watcher flow

## Test plan
- [x] Documentation changes only - no code changes
- [x] All references are consistent with current codebase

Note: This is a partial update for Issue #166. Wiki pages will be addressed separately.

🤖 Generated with [Claude Code](https://claude.ai/code)